### PR TITLE
[RFC 0014] Improve import from derivation

### DIFF
--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -9,7 +9,8 @@ related-issues: (will contain links to implementation PRs)
 # Summary
 [summary]: #summary
 
-Fix some issues with import-from-derivation so it is nice to use and suitable for use in nixpkgs.
+Fix some issues with importing from derivations so it is nicer to use both manually and with CI.
+Once this RFC is implemented, hydra.nixos.org should allow importing from derivations.
 
 # Motivation
 [motivation]: #motivation

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -2,7 +2,7 @@
 feature: import-from-derivation
 start-date: 2017-05-19
 author: John Ericson (@Ericson2314)
-co-authors: (find a buddy later to help our with the RFC)
+co-authors: Joe Hermaszewski (@expipiplus1)
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -19,7 +19,7 @@ Sometimes the entire dependent graph cannot be known statically (before any buil
 Examples of this would be a package with its own nix-based build system—the dependency must be downloaded first,
 or leveraging a language specific build tool (Cabal, Cargo, etc) to generate a build plan.
 
-Import-from-derivation and recursive Nix are two ways to achieve this dynamism—the interleaving of planning the graph and building it.
+Import-from-derivation and recursive Nix are two ways to achieve this dynamism—the interleaving of planning the build graph and executing it.
 Implementation-wise, however, they are completely orthogonal so there's no reason not work on both.
 
 Currently there are some issues with import-from-derivation, however. Per @shlevy's read-only recursive nix RFC:

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -1,0 +1,47 @@
+---
+feature: (fill me in with a unique ident, my_awesome_feature)
+start-date: (fill me in with today's date, YYYY-MM-DD)
+author: (name of the main author)
+co-authors: (find a buddy later to help our with the RFC)
+related-issues: (will contain links to implementation PRs)
+---
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+# Detailed design
+[design]: #detailed-design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the ecosystem to understand, and implement.  This should get
+into specifics and corner-cases, and include examples of how the feature is
+used.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+[alternatives]: #alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+What parts of the design are still TBD or unknowns?
+
+# Future work
+[future]: #future-work
+
+What future work, if any, would be implied or impacted by this feature
+without being directly part of the work?

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -28,6 +28,8 @@ Currently there are some issues with import-from-derivation, however. Per @shlev
 
   This is solved by simply making dry-run not build imported derivations.
   Those imports instead become stuck terms, and the derivations blocking them are enqueued.
+  Moreover, the conceptual layering of the nix language and the derivation builder is preserved:
+  While yes, in non-dry-run mode the evaluator will still need to invoke the builder, the builder need not know anything about evaluation.
 
 - *Import-from-derivation won't work if your expression-producing build needs to run on a different machine than your evaluating machine, unless you have distributed builds set up at evaluation time*
 

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -68,7 +68,7 @@ The partial evaluator, on encountering stuck terms, will log the unbuilt derivat
 
 ## CLI
 
-This is taken from issue XXX.
+This is taken from issue https://github.com/NixOS/nix/issues/666.
 `nix-build --dry-run` will do a single round of partial evaluation, and print out the set of unbuilt imported derivations just as it would the build plan in the case that evaluation doesn't complete.
 `nix-build --dry-run=n` will perform `n` rounds of evaluation, and then building unbuilt derivations, and then print the build plan or unbuilt imported derivations.
 `nix-build --dry-run` is thus a synonym of `nix-build --dry-run=0`.

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -1,7 +1,7 @@
 ---
-feature: (fill me in with a unique ident, my_awesome_feature)
-start-date: (fill me in with today's date, YYYY-MM-DD)
-author: (name of the main author)
+feature: import-from-derivation
+start-date: 2017-05-19
+author: John Ericson (@Ericson2314)
 co-authors: (find a buddy later to help our with the RFC)
 related-issues: (will contain links to implementation PRs)
 ---
@@ -9,39 +9,105 @@ related-issues: (will contain links to implementation PRs)
 # Summary
 [summary]: #summary
 
-One paragraph explanation of the feature.
+Fix some issues with import-from-derivation so it is nice to use and suitable for use in nixpkgs.
 
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
+Sometimes the entire dependent graph cannot be known statically (before any building).
+Examples of this would be a package with its own nix-based build system—the dependency must be downloaded first,
+or leveraging a language specific build tool (Cabal, Cargo, etc) to generate a build plan.
+
+Import-from-derivation and recursive Nix are two ways to achieve this dynamism—the interleaving of planning the graph and building it.
+Implementation-wise, however, they are completely orthogonal so there's no reason not work on both.
+
+Currently there are some issues with import-from-derivation, however. Per @shlevy's read-only recursive nix RFC:
+
+- *Import-from-derivation breaks dry-run evaluation and separation of evaluation-time from build-time.*
+
+  This is solved by simply making dry-run not build imported derivations.
+  Those imports instead become stuck terms, and the derivations blocking them are enqueued.
+
+- *Import-from-derivation won't work if your expression-producing build needs to run on a different machine than your evaluating machine, unless you have distributed builds set up at evaluation time*
+
+  By not building during evaluation, we can use remote build machines just as usual.
+
+This RFC details the fixes to those problems.
 
 # Detailed design
 [design]: #detailed-design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the ecosystem to understand, and implement.  This should get
-into specifics and corner-cases, and include examples of how the feature is
-used.
+The fundamental change is rather than evaluation unconditionally triggering execution, evaluation will suspend yielding the execution needed to be done so it can make further progress on resumption.
+This is probably easier to explain in terms of the implementation steps needed.
+
+## Black-hole unwinding
+
+There's currently a bug with nix-repl where if computation is interrupted (say with `SIGINT`), and the same computation is begun again, one will get an infinite recursion error despite there being no infinite recursion.
+This is because the thunks stay black-holed—the indication that they are currently evaluated—despite the computation being aborted.
+To fix this, we want aborted computations to instead unwind their stack, un-black-holing any thunks back the way they were before.
+Mathematically, black-hole unwinding ensures that evaluation is idempotent.
+
+## Partial evaluation
+
+The next step is to extend the nix evaluator to support partial evaluation—i.e. evaluation in the presence of *stuck terms* which cannot be normalized.
+The partial evaluator, on encountering a stuck term, will unwind (while unblack-holing thunks) until it finds another thunk to force—forcing binary primops for example force both subterms.
+Eventually nothing is left to evaluate, and the evaluator returns.
+[This is all completely standard for partial evaluation.]
+
+## Import-from-derivation as stuck terms.
+
+To leverage our partial evaluator, we deem imports of derivations as stuck terms.
+We unconditionally evaluate the argument to `import`, but `import <unbuilt-store-path>` is stuck.
+The partial evaluator, on encountering stuck terms, will log the unbuilt derivations, and return the set of all encountered ones (in the case that evaluation is not total).
+
+## CLI
+
+This is taken from issue XXX.
+`nix-build --dry-run` will do a single round of partial evaluation, and print out the set of unbuilt imported derivations just as it would the build plan in the case that evaluation doesn't complete.
+`nix-build --dry-run=n` will perform `n` rounds of evaluation, and then building unbuilt derivations, and then print the build plan or unbuilt imported derivations.
+`nix-build --dry-run` is thus a synonym of `nix-build --dry-run=0`.
+`nix-build --dry-run=infinity` is the semantics of `--dry-run` today—perform as many rounds as needed to get the final static build plan.
+
+Because we pause evaluation each round, we can build the imported derivations "normally".
+That includes taking advantage of build remotes, which avoids the problem of import from derivation DOSing the hydra evaluator and or imported derivations requiring a different platform than the evaluation machine.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+Overlap with recursive nix.
 
 # Alternatives
 [alternatives]: #alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+Recursive nix alone. @shelvy raised some other downsides of import-from-derivation, not solved by this RFC, which I'll address below:
+
+- *Import-from-derivation doesn't keep a connection between the build rule and its dependencies: the expressions imported-from-derivation are not discoverable from the final drv.*
+
+  There is nothing stopping us from logging this as extra metadata, but I'm not sure how this information is useful.
+
+- *Import-from-derivation requires you to know up front all of the possible branches that involve recursive evaluation, whereas recursive nix can branch based on information derived during the build itself.*
+
+  This is fair. There's a CPS-like encoding where one always imports a derivation, but it's something one would want to write.
+  But, more importantly, we do not need to choose between improved import-from-derivation and recursive nix.
+
+- *Certain far-future goals, such as a gcc frontend that does all compilations as nested derivations to get free distcc and ccache, would be very impractical to shoehorn into an import-from-derivation regime.*
+
+  We can do both.
+
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still TBD or unknowns?
+None.
 
 # Future work
 [future]: #future-work
 
-What future work, if any, would be implied or impacted by this feature
-without being directly part of the work?
+This unlocks lots of future work in Nixpkgs:
+
+ - Leveraging language-specific tools to generate plans nix builds, rather than reimplementing much of those tools.
+
+ - Simply fetching and importing packages which use Nix for their build system, like Nix itself and hydra, rather than vendoring that build system in.
+
+Another future project would be some speculative strictness to allow one round of evaluation to return *both* a partial build plan and stuck imported derivations.
+Currently the plan must still be evaluated entirely before any building of "actually needed" derivations, i.e. those which *aren't* imported, begins.

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -85,7 +85,7 @@ Overlap with recursive Nix.
 # Alternatives
 [alternatives]: #alternatives
 
-Just do recursive Nix alone. @shelvy raised some other downsides of import-from-derivation, not solved by this RFC, which I'll address below:
+Just do recursive Nix alone. @shlevy raised some other downsides of import-from-derivation, not solved by this RFC, which I'll address below:
 
 - *Import-from-derivation doesn't keep a connection between the build rule and its dependencies: the expressions imported-from-derivation are not discoverable from the final drv.*
 

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -36,6 +36,9 @@ Currently there are some issues with import-from-derivation, however. Per @shlev
   By not building during evaluation, we can use remote build machines just as usual.
 
 This RFC details the fixes to those problems.
+With these fixes made, hydra.nixos.org should change policy to allow importing from derivations.
+In turn, Nixpkgs can stop including auto-generated code, such as the dumps of Hackage.
+This will vastly decrease churn, decreasing growth of that repository.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0000-import-from-derivation.md
+++ b/rfcs/0000-import-from-derivation.md
@@ -16,19 +16,19 @@ Once this RFC is implemented, hydra.nixos.org should allow importing from deriva
 [motivation]: #motivation
 
 Sometimes the entire dependent graph cannot be known statically (before any building).
-Examples of this would be a package with its own nix-based build system—the dependency must be downloaded first,
+Examples of this would be a package with its own Nix-based build system—the dependency must be downloaded first,
 or leveraging a language specific build tool (Cabal, Cargo, etc) to generate a build plan.
 
 Import-from-derivation and recursive Nix are two ways to achieve this dynamism—the interleaving of planning the build graph and executing it.
-Implementation-wise, however, they are completely orthogonal so there's no reason not work on both.
+Implementation-wise, however, they are completely orthogonal so there's no reason not to work on both.
 
-Currently there are some issues with import-from-derivation, however. Per @shlevy's read-only recursive nix RFC:
+Currently there are some issues with import-from-derivation, however. Per @shlevy's read-only recursive Nix RFC:
 
 - *Import-from-derivation breaks dry-run evaluation and separation of evaluation-time from build-time.*
 
   This is solved by simply making dry-run not build imported derivations.
   Those imports instead become stuck terms, and the derivations blocking them are enqueued.
-  Moreover, the conceptual layering of the nix language and the derivation builder is preserved:
+  Moreover, the conceptual layering of the Nix language and the derivation builder is preserved:
   While yes, in non-dry-run mode the evaluator will still need to invoke the builder, the builder need not know anything about evaluation.
 
 - *Import-from-derivation won't work if your expression-producing build needs to run on a different machine than your evaluating machine, unless you have distributed builds set up at evaluation time*
@@ -48,14 +48,14 @@ This is probably easier to explain in terms of the implementation steps needed.
 
 ## Black-hole unwinding
 
-There's currently a bug with nix-repl where if computation is interrupted (say with `SIGINT`), and the same computation is begun again, one will get an infinite recursion error despite there being no infinite recursion.
+There's currently a bug with `nix-repl` where if computation is interrupted (say with `SIGINT`), and the same computation is begun again, one will get an infinite recursion error despite there being no infinite recursion.
 This is because the thunks stay black-holed—the indication that they are currently evaluated—despite the computation being aborted.
 To fix this, we want aborted computations to instead unwind their stack, un-black-holing any thunks back the way they were before.
 Mathematically, black-hole unwinding ensures that evaluation is idempotent.
 
 ## Partial evaluation
 
-The next step is to extend the nix evaluator to support partial evaluation—i.e. evaluation in the presence of *stuck terms* which cannot be normalized.
+The next step is to extend the Nix evaluator to support partial evaluation—i.e. evaluation in the presence of *stuck terms* which cannot be normalized.
 The partial evaluator, on encountering a stuck term, will unwind (while unblack-holing thunks) until it finds another thunk to force—forcing binary primops for example force both subterms.
 Eventually nothing is left to evaluate, and the evaluator returns.
 [This is all completely standard for partial evaluation.]
@@ -80,12 +80,12 @@ That includes taking advantage of build remotes, which avoids the problem of imp
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Overlap with recursive nix.
+Overlap with recursive Nix.
 
 # Alternatives
 [alternatives]: #alternatives
 
-Recursive nix alone. @shelvy raised some other downsides of import-from-derivation, not solved by this RFC, which I'll address below:
+Just do recursive Nix alone. @shelvy raised some other downsides of import-from-derivation, not solved by this RFC, which I'll address below:
 
 - *Import-from-derivation doesn't keep a connection between the build rule and its dependencies: the expressions imported-from-derivation are not discoverable from the final drv.*
 
@@ -94,7 +94,7 @@ Recursive nix alone. @shelvy raised some other downsides of import-from-derivati
 - *Import-from-derivation requires you to know up front all of the possible branches that involve recursive evaluation, whereas recursive nix can branch based on information derived during the build itself.*
 
   This is fair. There's a CPS-like encoding where one always imports a derivation, but it's something one would want to write.
-  But, more importantly, we do not need to choose between improved import-from-derivation and recursive nix.
+  But, more importantly, we do not need to choose between improved import-from-derivation and recursive Nix.
 
 - *Certain far-future goals, such as a gcc frontend that does all compilations as nested derivations to get free distcc and ccache, would be very impractical to shoehorn into an import-from-derivation regime.*
 
@@ -111,7 +111,7 @@ None.
 
 This unlocks lots of future work in Nixpkgs:
 
- - Leveraging language-specific tools to generate plans nix builds, rather than reimplementing much of those tools.
+ - Leveraging language-specific tools to generate plans Nix builds, rather than reimplementing much of those tools.
 
  - Simply fetching and importing packages which use Nix for their build system, like Nix itself and hydra, rather than vendoring that build system in.
 


### PR DESCRIPTION
Fix some issues with importing from derivations so it is nicer to use both manually and with CI. If this RFC is implemented, hydra.nixos.org should allow importing from derivations.

[Rendered](https://github.com/Ericson2314/nix-rfcs/blob/import-from-derivation/rfcs/0000-import-from-derivation.md)