### PR TITLE
[RFC 0056] CI all Nix PRs

### DIFF
--- a/rfcs/0000-ci-all-nix-prs.md
+++ b/rfcs/0000-ci-all-nix-prs.md
@@ -1,0 +1,49 @@
+---
+feature: (fill me in with a unique ident, my_awesome_feature)
+start-date: (fill me in with today's date, YYYY-MM-DD)
+author: (name of the main author)
+co-authors: (find a buddy later to help our with the RFC)
+shepherd-team: (names, to be nominated and accepted by RFC steering committee)
+shepherd-leader: (name to be appointed by RFC steering committee)
+related-issues: (will contain links to implementation PRs)
+---
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+# Detailed design
+[design]: #detailed-design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the ecosystem to understand, and implement.  This should get
+into specifics and corner-cases, and include examples of how the feature is
+used.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+[alternatives]: #alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+What parts of the design are still TBD or unknowns?
+
+# Future work
+[future]: #future-work
+
+What future work, if any, would be implied or impacted by this feature
+without being directly part of the work?

--- a/rfcs/0000-ci-all-nix-prs.md
+++ b/rfcs/0000-ci-all-nix-prs.md
@@ -49,7 +49,7 @@ More process to follow.
 1. Merely build all PRs with OfBorg.
    This is still far better than the status quo, but has the disadvantage that master must still be rebuilt as OfBorg and Hydra do not share a cache.
 
-2. Merely build all approved PRs, and maintainers are still allowed to merge broken ones / not take care to avoid untested merge commits.
+2. Merely build all approved PRs with Hydra, but maintainers are still allowed to merge broken ones / not take care to avoid untested merge commits.
    This is better still, but master could still be broken, even if only working branches are merged due to the merges not being tested.
 
 3. Build all PRs with Hydra.

--- a/rfcs/0000-ci-all-nix-prs.md
+++ b/rfcs/0000-ci-all-nix-prs.md
@@ -1,7 +1,7 @@
 ---
-feature: (fill me in with a unique ident, my_awesome_feature)
-start-date: (fill me in with today's date, YYYY-MM-DD)
-author: (name of the main author)
+feature: ci-all-nix-prs
+start-date: 2019-10-30
+author: John Ericson (@Ericson2314)
 co-authors: (find a buddy later to help our with the RFC)
 shepherd-team: (names, to be nominated and accepted by RFC steering committee)
 shepherd-leader: (name to be appointed by RFC steering committee)
@@ -11,39 +11,50 @@ related-issues: (will contain links to implementation PRs)
 # Summary
 [summary]: #summary
 
-One paragraph explanation of the feature.
+Build all Nix PRs in CI.
+Do not merge any PR until it passes CI.
 
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
+There is a (famous blog post)[blog-post] that everyone is sloppy and doing CI wrong.
+This isn't just bad for releasing software smoothly, but also increases the burden for new contributors because it is harder to judge the correctness of PRs at a glance (is it broken? Did I break it?).
+I personally find it harder to contribute, I have to worry about double checking all my work on platforms I don't have as-easy access to, like Darwin.
+
+We cannot yet do this for all of Nixpkgs, sadly, due to resource limits.
+But, there is no reason we cannot do it for Nix itself.
 
 # Detailed design
 [design]: #detailed-design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the ecosystem to understand, and implement.  This should get
-into specifics and corner-cases, and include examples of how the feature is
-used.
+Set up Hydra declarative jobsets to build all Nix PRs.
+Those with merge access should be instructed not to merge a PR until CI passes.
+Merge master into PRs or rebase before merge as a crude stop-gap to avoid master becoming an untested tree due to a merge commit.
+
+If Hydra gains the ability to keep master always working obviating the manual steps above beyond the PR jobs, use that ability.
+
+If a new CI is used, ensure that is also keeps master in an always-building state.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+More process to follow.
 
 # Alternatives
 [alternatives]: #alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+Merely build all PRs, and maintainers are still allowed to merge broken ones / not take care to avoid untested merge commits.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still TBD or unknowns?
+Nothing.
 
 # Future work
 [future]: #future-work
 
-What future work, if any, would be implied or impacted by this feature
-without being directly part of the work?
+- Remove the manual parts of this process.
+
+- Also apply to other smaller official repos, like `cabal2nix`.
+
+[blog-post]: https://graydon2.dreamwidth.org/1597.html

--- a/rfcs/0000-ci-all-nix-prs.md
+++ b/rfcs/0000-ci-all-nix-prs.md
@@ -17,7 +17,7 @@ Do not merge any PR until it passes CI.
 # Motivation
 [motivation]: #motivation
 
-There is a [famous blog post](blog-post) about how everyone is sloppy and doing CI wrong.
+There is a [famous blog post][blog-post] about how everyone is sloppy and doing CI wrong.
 This isn't just bad for releasing software smoothly, but also increases the burden for new contributors because it is harder to judge the correctness of PRs at a glance (is it broken? Did I break it?).
 I personally find it harder to contribute, I have to worry about double checking all my work on platforms I don't have as-easy access to, like Darwin.
 


### PR DESCRIPTION
Build all Nix PRs in CI. Do not merge any PR until it passes CI.

This has been discussed for Nixpkgs, but it should be more economically feasible for just Nix.

[Rendered](https://github.com/Ericson2314/nix-rfcs/blob/ci-all-nix-prs/rfcs/0000-ci-all-nix-prs.md)