### PR TITLE
[RFC 0058] Named Ellipses

### DIFF
--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -22,6 +22,8 @@ This is pretty simple so it#s redundant with the summary:
 # Detailed design
 [design]: #detailed-design
 
+`{...@extraargs}: extraargs` should yield an attrset the extra arguments "in" `...`.
+
 Help?
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -17,7 +17,7 @@ It should be possible to bind ellipses to a name in a function argument definiti
 [motivation]: #motivation
 This is pretty simple so it#s redundant with the summary:
 - I think it makes sense to be able to refer to "the rest of the arguments" as a first class object
-- This should also allow nixing a lot of usages of the `removeAttrs` pattern
+- This should also allow nixing a lot of usages of the `removeAttrs` pattern TODO: substantiate this
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -22,7 +22,7 @@ This is pretty simple so it#s redundant with the summary:
 # Detailed design
 [design]: #detailed-design
 
-`{...@extraargs}: extraargs` should yield an attrset the extra arguments "in" `...`.
+`{...@extraargs}: extraargs` should yield as an attrset the extra arguments "in" `...`.
 
 Help?
 

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -1,7 +1,7 @@
 ---
 feature: Named Ellipses OR function argument consistency
 start-date: (fill me in with today's date, YYYY-MM-DD)
-author: @deliciouslytyped
+author: deliciouslytyped
 co-authors: (find a buddy later to help our with the RFC)
 shepherd-team: (names, to be nominated and accepted by RFC steering committee)
 shepherd-leader: (name to be appointed by RFC steering committee)

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -12,7 +12,7 @@ related-issues:
 # Summary
 [summary]: #summary
 
-It should be possible to bind ellipses to a name in a function definition like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and could remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
+It should be possible to bind a name to ellipses in a function definition like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and could remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
 
 TODO: The latter could be substantiated.
 

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -1,0 +1,53 @@
+---
+feature: Named Ellipses OR function argument consistency
+start-date: (fill me in with today's date, YYYY-MM-DD)
+author: @deliciouslytyped
+co-authors: (find a buddy later to help our with the RFC)
+shepherd-team: (names, to be nominated and accepted by RFC steering committee)
+shepherd-leader: (name to be appointed by RFC steering committee)
+related-issues: (will contain links to implementation PRs)
+---
+
+# Summary
+[summary]: #summary
+
+It should be possible to bind ellipses to a name in a function argument definitions like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and would remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
+
+# Motivation
+[motivation]: #motivation
+This is pretty simple so it#s redundant with the summary:
+- I think it makes sense to be able to refer to "the rest of the arguments" as a first class object
+- This should also allow nixing a lot of usages of the `removeAttrs` pattern
+
+# Detailed design
+[design]: #detailed-design
+
+Help?
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the ecosystem to understand, and implement.  This should get
+into specifics and corner-cases, and include examples of how the feature is
+used.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+None?
+This implements syntax that would not have worked before and so in theory shouldn't cause breakage in the Nix ecosystem. [Citation Needed]
+
+# Alternatives
+[alternatives]: #alternatives
+None?
+
+Not doing this would not have any major impact besides not making nix and nixpkgs nicer to use.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+Should scope of this be expanded to binding any function argument to new names - for consistency, even though that might be considered redundant?
+
+
+# Future work
+[future]: #future-work
+None?
+
+# Bibliography
+Named ellipses - https://github.com/NixOS/nix/issues/2998

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -19,7 +19,8 @@ Nixpkgs often gets commits like https://github.com/NixOS/nixpkgs/commit/a5065329
 # Detailed design
 [design]: #detailed-design
 
-`{...@extraargs}: extraargs` should yield as an attrset the extra arguments "in" `...`.
+The intent of this syntax is for `{...@args}:` to behave as close to the current `{...} @ args:`
+ as practical. As both `args @ {…}` and `{…} @ args` forms happen in Nixpkgs, both would be supported for named ellipses, too. As `args @ {args}: ` is an error in Nix because of duplicate argument names, so should be `{extra, ...@extra}: `. As `(a @ { ... }: a) {a=1;}` returns `{a=1;}`, so should `({ a @ ... }: a) {a=1;}`. ```
 
 TODO: consider what other languages like Haskell do
 

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -21,6 +21,8 @@ TODO: The latter could be substantiated.
 
 `{...@extraargs}: extraargs` should yield as an attrset the extra arguments "in" `...`.
 
+TODO: consider what other languages like Haskell do
+
 # Drawbacks
 [drawbacks]: #drawbacks
 None? This implements syntax that would not have worked before and so in theory shouldn't cause breakage in the Nix ecosystem. [Citation Needed]

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -3,8 +3,8 @@ feature: Named Ellipses
 start-date: 2019-11-14
 author: deliciouslytyped
 co-authors: none
-shepherd-team: (names, to be nominated and accepted by RFC steering committee)
-shepherd-leader: (name to be appointed by RFC steering committee)
+shepherd-team: Eelco Dolstra, Michael Raskin, jD91mZM2
+shepherd-leader: Michael Raskin
 related-issues:
   Named Ellipses - https://github.com/NixOS/nix/issues/2998
 ---

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -1,5 +1,5 @@
 ---
-feature: Named Ellipses OR function argument consistency
+feature: Named Ellipses
 start-date: 2019-11-14
 author: deliciouslytyped
 co-authors: none
@@ -19,8 +19,10 @@ Nixpkgs often gets commits like https://github.com/NixOS/nixpkgs/commit/a5065329
 # Detailed design
 [design]: #detailed-design
 
-The intent of this syntax is for `{...@args}:` to behave as close to the current `{...} @ args:`
- as practical. As both `args @ {…}` and `{…} @ args` forms happen in Nixpkgs, both would be supported for named ellipses, too. As `args @ {args}: ` is an error in Nix because of duplicate argument names, so should be `{extra, ...@extra}: `. As `(a @ { ... }: a) {a=1;}` returns `{a=1;}`, so should `({ a @ ... }: a) {a=1;}`. ```
+The intent of this syntax is for `{...@args}:` to behave as consistent with `{...} @ args:`
+ as practical. As both `args @ {…}` and `{…} @ args` forms happen in Nixpkgs, both would be supported for named ellipses, too. 
+ 
+ As `args @ {args}: ` is an error in Nix because of duplicate argument names, so should be `{extra, ...@extra}: `. As `(a @ { ... }: a) {a=1;}` returns `{a=1;}`, so should `({ a @ ... }: a) {a=1;}`. ```
 
 TODO: consider what other languages like Haskell do
 
@@ -30,8 +32,4 @@ This increases the amount of syntax Nix has, thus creating some maintenance cost
 
 # Alternatives
 [alternatives]: #alternatives
-Not doing this would not have any major impact besides not making nix and nixpkgs nicer to use.
-
-# Unresolved questions
-[unresolved]: #unresolved-questions
-Should scope of this be expanded to binding any function argument to new names - for consistency, even though that might be considered redundant?
+Not doing this would not have any major impact besides not making Nix and nixpkgs nicer to use.

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -1,11 +1,12 @@
 ---
 feature: Named Ellipses OR function argument consistency
-start-date: (fill me in with today's date, YYYY-MM-DD)
+start-date: 2019-11-14
 author: deliciouslytyped
-co-authors: (find a buddy later to help our with the RFC)
+co-authors: none
 shepherd-team: (names, to be nominated and accepted by RFC steering committee)
 shepherd-leader: (name to be appointed by RFC steering committee)
-related-issues: (will contain links to implementation PRs)
+related-issues:
+  Named Ellipses - https://github.com/NixOS/nix/issues/2998
 ---
 
 # Summary
@@ -13,43 +14,21 @@ related-issues: (will contain links to implementation PRs)
 
 It should be possible to bind ellipses to a name in a function argument definitions like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and would remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
 
-# Motivation
-[motivation]: #motivation
-This is pretty simple so it#s redundant with the summary:
-- I think it makes sense to be able to refer to "the rest of the arguments" as a first class object
-- This should also allow nixing a lot of usages of the `removeAttrs` pattern TODO: substantiate this
+TODO: The latter point should be substantiated.
 
 # Detailed design
 [design]: #detailed-design
 
 `{...@extraargs}: extraargs` should yield as an attrset the extra arguments "in" `...`.
 
-Help?
-
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the ecosystem to understand, and implement.  This should get
-into specifics and corner-cases, and include examples of how the feature is
-used.
-
 # Drawbacks
 [drawbacks]: #drawbacks
-None?
-This implements syntax that would not have worked before and so in theory shouldn't cause breakage in the Nix ecosystem. [Citation Needed]
+None? This implements syntax that would not have worked before and so in theory shouldn't cause breakage in the Nix ecosystem. [Citation Needed]
 
 # Alternatives
 [alternatives]: #alternatives
-None?
-
 Not doing this would not have any major impact besides not making nix and nixpkgs nicer to use.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 Should scope of this be expanded to binding any function argument to new names - for consistency, even though that might be considered redundant?
-
-
-# Future work
-[future]: #future-work
-None?
-
-# Bibliography
-Named ellipses - https://github.com/NixOS/nix/issues/2998

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -25,7 +25,7 @@ TODO: consider what other languages like Haskell do
 
 # Drawbacks
 [drawbacks]: #drawbacks
-None? This implements syntax that would not have worked before and so in theory shouldn't cause breakage in the Nix ecosystem. [Citation Needed]
+This increases the amount of syntax Nix has, thus creating some maintenance cost both for Nix itself, and for tools intended to work with Nix syntax (from highlighting to hnix)
 
 # Alternatives
 [alternatives]: #alternatives

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -14,7 +14,7 @@ related-issues:
 
 It should be possible to bind a name to ellipses in a function definition like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and could remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
 
-TODO: The latter could be substantiated.
+Nixpkgs often gets commits like https://github.com/NixOS/nixpkgs/commit/a50653295df5e2565b4a6a316923f9e939f1945b with code that would be cleaner without the need for extra `removeAttrs`.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0057-named-ellipses.md
+++ b/rfcs/0057-named-ellipses.md
@@ -12,9 +12,9 @@ related-issues:
 # Summary
 [summary]: #summary
 
-It should be possible to bind ellipses to a name in a function argument definitions like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and would remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
+It should be possible to bind ellipses to a name in a function definition like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and could remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.
 
-TODO: The latter point should be substantiated.
+TODO: The latter could be substantiated.
 
 # Detailed design
 [design]: #detailed-design


### PR DESCRIPTION
It should be possible to bind a name to ellipses in a function definition like `{ a, ...@extra }: null`, and `{ a, extra@... }: null`. This makes intuitive sense, and could remove the need for a lot of uses of `removeAttrs` that really just want to refer to the contents of ellipses.

[Rendered](https://github.com/deliciouslytyped/rfcs/blob/patch-1/rfcs/0057-named-ellipses.md)

Edit:
Proposed discussion point:
Should scope of this be expanded to binding any function argument to new names - for consistency, even though that might be considered redundant? E.g.: `a@{b@c, d@...}: null`
Maybe it's preferable to get this simple RFC through first though.