### PR TITLE
Make the detailed design terse by separating examples

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -22,10 +22,19 @@ outcome?
 # Detailed design
 [design]: #detailed-design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the ecosystem to understand, and implement.  This should get
-into specifics and corner-cases, and include examples of how the feature is
-used.
+This is the core, normative part of the RFC. Explain the design in enough
+detail for somebody familiar with the ecosystem to understand, and implement.
+This should get into specifics and corner-cases. Yet, this section should also
+be terse, avoiding redundancy even at the cost of clarity.
+
+# Examples and Interactions
+[examples-and-interactions]: #examples-and-interactions
+
+This section illustrates the detailed design. This section should clarify all
+confusion the reader has from the previous sections. It is especially important
+to counterbalance the desired terseness of the detailed design; if you feel
+your detailed design is rudely short, consider making this section longer
+instead.
 
 # Drawbacks
 [drawbacks]: #drawbacks


### PR DESCRIPTION
A few times I have asked people to separate examples from the core change we are deciding on, to have a terse, precise, and unambiguous normative bit that won't become more confusing when the context that makes something wordier flow is lost over time.

There is prior art for this sort of template revision:

In https://github.com/ghc-proposals/ghc-proposals/pull/251 it is pointed out that the combined section *both* be too wordy and have too few clarifying examples. This is a good point, lest this template change seem to skewed in favor of exports and against beginners: Everyone can win when we have terser detailed designs and far more examples. 

https://github.com/rust-lang/rfcs/pull/2059 is not an exact match, but I think is closer in spirit given th way things worked in practice. Before that change, the "how do we teach this" section was excessively beginner-oriented, so the detailed design would still have many intermediate-oriented details. After that change, I think it was clearer that everyone can benefit from a guide / examples, and no one should feel obligated to immediately obligated to understand the reference explanation and all its ramifications on the first pass-through. This freed that section to be more terse and precise.   