### PR TITLE
[RFC 0077] Stale Issues Amendement

### DIFF
--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -59,6 +59,10 @@ political correctness (judging by the discussions on RFC 51).
 - Mark PRs as stale after 90 days
 - Mark issues as stale after 60 days
 - Keep the policy of never closing either PRs or Issues.
+- Add `2.status: never-stale`, which maintainers can use on long running or umbrella issues.
+
+_Note: non-maintainers are sufficiently unlikely to open truely long-runnig or umbrella 
+issues without a maintainer stepping up to prevent them from getting marked as stale._
 
 # Examples and Interactions
 [examples-and-interactions]: #examples-and-interactions

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -228,5 +228,10 @@ At the time of writing, no unresolved questions apear of relevance.
 # Future work
 [future]: #future-work
 
-Neutrally estimate the current share of instances where the drawback
-manifests based on observable data.
+A stale-bot interaction can be a good opportunity for doing nothing except
+enriching the issue's or PR's metadata through labelling.
+
+So in order to make the most out of a timely stalebot intervantion, we would
+have to combine it with a consistent and practical framework of labelling
+issues. This however, is subject of another RFC and cannot be addressd in this
+RFC.

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -98,14 +98,12 @@ to a more practical level.
 
 If this first interaction has triggered further action, then this further
 action might trigger a notification. Such notification will alsways be
-triggered by a human.
+triggered by a human. Consequetly any added notification over the the RFC
+state, is triggered by human intervention.
 
-Consequetly any added notification over the rpe RFC state, is triggered by
-human intervention.
-
-That is, unless the issue or PR goes stale _again_. But going _stale_, which
-means **impaired in vigor or effectiveness**, _again_ is by itself a valuable
-information that is beeing broadcasted implicitly by their notification.
+That is, unless the issue or PR goes stale _again_. But going stale _again_,
+which means **impaired in vigor or effectiveness _again_**, is by itself a
+valuable information that is beeing broadcasted by the notification.
 
 # Supporting Data
 [data]: #supporting-data

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -44,20 +44,24 @@ at bearably low levels, which everyone can live with._
 # Motivation
 [motivation]: #motivation
 
-Under the renewed definition of _stale_, people are betrayed. 
+Under the correct (as per Merriam Webster) definition of _stale_, people are betrayed. 
 
 They are not told the truth, though the facts are long evident.
 
 A majority of issues or PRs with no interaction for quite short period
 of times already (maybe 3-6 weeks) has a lesser change of "success".
 
-People with vested interest should see the _stale_ label and be prompted
-to think: "Oh, I need this, too. Damn, it's stale. Let's have a look
-and do something to help out."
+However we also want to avoid _false positives_, that is issues or PRs
+marked as **impareid in vigor or effectivenss**, even though they are not.
 
-An issue that hasn't been interacted with for 60 days or a PR for 90 days,
-in the vast majority of cases, deserves this hint out of fariness,
-honesty and transprency.
+This is a question of threshold and summary judgment. 60 days (2 months) for issues 
+and 90 (3 months) for PRs is probably a good enough improvmeent over the current 180 days.
+
+With shorter periods, people are also mor likely to still remember the relevant details, 
+so it gets easier for them to react in actionable ways to the bot's friendly reminder.
+
+Cases, where these dynamics, don't regularily aply (such as umbrell issues, etc.), 
+should be provided with an escape hatchi which maintainers can activate.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -51,11 +51,9 @@ People with vested interest should see the _stale_ label and be prompted
 to think: "Oh, I need this, too. Damn, it's stale. Let's have a look
 and do something to help out."
 
-An issue that hasn't been interacted with for 60 days or a PR for 90 days
-and in the vast majority of cases deserves this hint out of fariness.
-
-Honesty and transparency are by far more effective than any perceived
-political correctness (judging by the discussions on RFC 51).
+An issue that hasn't been interacted with for 60 days or a PR for 90 days,
+in the vast majority of cases, deserves this hint out of fariness,
+honesty and transprency.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -88,7 +88,7 @@ With a renewed definition of the word _stale_ and removing an overly emotional
 meaning by virtue of this very PR, there is no reason to adversely interpret
 a bot spelling out the facts.
 
-Regular subscriber might get notiviations they do not find immediatly
+Regular subscriber might get notifications they do not find immediatly
 actionable for them personally. However, the bot is inteded to help authors,
 not (silent) subscribers. It is assumed that subscribers wisely choose
 and actively manage how they spread their limmited attention. At any rate,
@@ -110,7 +110,7 @@ might be in a particular context), judging by the 1750 unattended interventions,
 it blatantly failed. Since any such furthering would have left traces the stalebot
 would have picked up in any way.
 
-One reason for this might be that by the time the stae bot intervenes, the
+One reason for this might be that by the time the stale bot intervenes, the
 interest and memory has vanished to a point where even the friendly suggestions
 of the stalebot are completely ignored. This strongly supports reducing the
 inactivity period to _humanly bearable levels_ of an avearge person with an

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -17,36 +17,41 @@ RFC 51 implemented the stale bot with the following motivation:
 > 
 > By marking stale issues, we can more easily filter issues for ones that have at least one person interested in them.
 
-Under the interpretation of this motivation, the definition of stale was 
-settled at 180 days.
+Under this motivation, the inactivity period was chosen to be 180 days.
 
-This RFC modifies the motivation for marking issues as stale:
+This RFC proposes an alternative interpretation of "stale":
 
-_A stale issue (or PR) is an issue on which the discussion has went stale. It
-has no other semantic meaning than an aggregated indicator of individual
-preferences (to not interact on a particular issue or PR)._
+_A stale issue (or PR) is an issue on which the discussion has went stale._
 
-_Therefore, a PR goes stale after a 90 days period (vs previously 180 days)
-and an issue goes stale after a 60 days period (vs previously 180 days)._
+_Explicitly, it has no other semantic than this. It is a neutral 
+aggregated indicator of facts. It reflects the fact that 
+individuals did choose not to not interact on a particular issue or PR
+for an extended period of time._
+
+_180 days is too long of such extended period of time. People do relate
+"stale" with some shorter time frame. Therefore, a PR goes stale after
+a 90 days period (vs previously 180 days) and an issue goes stale after
+a 60 days period (vs previously 180 days)._
 
 # Motivation
 [motivation]: #motivation
 
-Under the renewed definition of _stale_ under this PR but the currently
-applied time periods, spectators based on their common understanding 
-are not told about  aggregate choices as a fair proxy of chances of 
-success by means of the stale label.
+Under the renewed definition of _stale_, people are betrayed. 
 
-This discourages spectators with vested interests from promoting issues,
-that are visibly exhibiting lack of interaction, and there by reduced
-chances of (prompt) "success".
+They are not told the truth, though the facts are long evident.
+
+A majority of issues or PRs with no interaction for quite short period
+of times already (maybe 3-6 weeks) has a lesser change of "success".
+
+People with vested interest should see the _stale_ label and be prompted
+to think: "Oh, I need this, too. Damn, it's stale. Let's have a look
+and do something to help out."
 
 An issue that hasn't been interacted with for 60 days or a PR for 90 days
-and in the vast majority of cases deserve an aggregate indication of
-those individual preferences for the above reason.
+and in the vast majority of cases deserves this hint out of fariness.
 
-Honesty and transparency are better in informing an individual's action
-than preceived political correctness (judging by the discussions on RFC 51).
+Honesty and transparency are by far more effective than any perceived
+political correctness (judging by the discussions on RFC 51).
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -23,6 +23,10 @@ This RFC proposes an alternative interpretation of "stale":
 
 _A stale issue (or PR) is an issue on which the discussion has went stale._
 
+_"Stale" in this context means (https://www.merriam-webster.com/dictionary/stale):_
+
+> impaired in vigor or effectiveness
+
 _Explicitly, it has no other semantic than this. It is a neutral 
 aggregated indicator of facts. It reflects the fact that 
 individuals did choose not to interact on a particular issue or PR

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -1,0 +1,95 @@
+---
+feature: stale-issues-amendment
+start-date: 2020-10-13
+author: blaggacao
+co-authors: (to be found)
+shepherd-team: (names, to be nominated and accepted by RFC steering committee)
+shepherd-leader: (name to be appointed by RFC steering committee)
+related-issues: https://github.com/NixOS/nixpkgs/pull/100460, https://github.com/NixOS/nixpkgs/pull/100462
+---
+
+# Summary
+[summary]: #summary
+
+RFC 51 implemented the stale bot with the following motivation:
+
+> We have a large number of open issues that have accumulated over the years. Not all of them are still valid and need our attention.
+> 
+> By marking stale issues, we can more easily filter issues for ones that have at least one person interested in them.
+
+Under the interpretation of this motivation, the definition of stale was 
+settled at 180 days.
+
+This RFC modifies the motivation for marking issues as stale:
+
+_A stale issue (or PR) is an issue on which the discussion has went stale. It
+has no other semantic meaning than an aggregated indicator of individual
+preferences (to not interact on a particular issue or PR)._
+
+_Therefore, a PR goes stale after a 90 days period (vs previously 180 days)
+and an issue goes stale after a 60 days period (vs previously 180 days)._
+
+# Motivation
+[motivation]: #motivation
+
+Under the renewed definition of _stale_ under this PR but the currently
+applied time preiods, spectators based on their common understanding 
+are not told about  aggregate choices as a fair proxy of chances of 
+success by means of the stale label.
+
+This discourages spectators with vested interests from promoting issues,
+that are visibly exhibiting lack of interaction, and there by reduced
+chances of (prompt) "success".
+
+An issue that hasn't been interacted with for 60 days or a PR for 90 days
+and in the vas majority of cases deserve an aggregate indication of
+those individual preferences for the above reason.
+
+Honesty and transparency are better in informing an individual's action
+than preceived political correctness (judging by the discussions on RFC 51).
+
+# Detailed design
+[design]: #detailed-design
+
+- Mark PRs as stale after 90 days
+- Mark issues as stale after 60 days
+- Keep the policy of never closing either PRs or Issues.
+
+# Examples and Interactions
+[examples-and-interactions]: #examples-and-interactions
+
+It should be noted under this section, that it only takes a comment
+to un-satale an issue or PR.
+
+It should be made clear, that stale does **not** mean either of
+the following:
+
+- bad
+- unimportant
+- invalid
+- not useful
+
+Or any similar deminishing interpretations. Stale just means an aggregate
+indcator of individual's choices to not interact.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+With a renewed definition of the word _stale_ and removing an overly emotional
+meaning by virtue of this very PR, there is no reason to adversely interpret
+a bot spelling out the facts.
+
+# Alternatives
+[alternatives]: #alternatives
+
+No alternatives have been considered.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+At the time of writing, no unresolved questions apear of relevance.
+
+# Future work
+[future]: #future-work
+
+No future work is required.

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -91,43 +91,44 @@ the following:
 Or any similar deminishing interpretations. Stale just means an aggregate
 indcator of individual's choices to not interact.
 
-# Drawbacks
-[drawbacks]: #drawbacks
+Please read carefully, this RFC does _not_ increase the **rate** of
+notifications by itslef. It just anticpiates the time to first interaction
+to a more practical level.
 
-With a renewed definition of the word _stale_ and removing an overly emotional
-meaning by virtue of this very PR, there is no reason to adversely interpret
-a bot spelling out the facts.
+If this first interaction has triggered further action, then this further
+action might trigger a notification. Such notification will alsways be
+triggered by a human.
 
-Regular subscriber might get notifications they do not find immediatly
-actionable for them personally. However, the bot is inteded to help authors,
-not (silent) subscribers. It is assumed that subscribers wisely choose
-and actively manage how they spread their limmited attention. At any rate,
-their interests should never outperform the interest of the auther (="owner").
+Consequetly any added notification over the rpe RFC state, is triggered by
+human intervention.
 
-At a closer look, increased notification is also a valuable _gain_ in information
-for those subscribers. Imagine: A topic went stale, then there where people moving
-things forward. Then it went stale _again_. If I'm subscribed to a topic of 
-_interest_, a second stale promts me to consider taking action.
+That is, unless the issue or PR goes stale _again_. But going _stale_, which
+means **impaired in vigor or effectiveness**, _again_ is by itself a valuable
+information that is beeing broadcasted implicitly by their notification.
 
-Some data: As of now, there are roughly 1750 open issues marked as stale, and
-roughly 450 stale issues were marked as closed. Even older ones. By definition
-of how the stale bot operates, this means the stale bot has failed in adequately
-prompting action. The data suggests, it is _not_ actionable.
+# Supporting Data
+[data]: #supporting-data
 
-There are a variety of possible reasons for this, but if we assume that the bot
-should have prompted the _author_ into "furthering the cause" (whatever that
-might be in a particular context), judging by the 1750 unattended interventions,
-it blatantly failed. Since any such furthering would have left traces the stalebot
-would have picked up in any way.
+As of now, there are roughly 1750 open issues marked as stale, and
+roughly 450 stale issues were marked as closeed.
 
-One reason for this might be that by the time the stale bot intervenes, the
-interest and memory has vanished to a point where even the friendly suggestions
-of the stalebot are completely ignored. This strongly supports reducing the
-inactivity period to _humanly bearable levels_ of an avearge person with an
-average memory.
+## Interpretation
 
-Another reason might be that the stalebot is not actionable, since too convoluted
-and wordy. So nobody reads it. Hence: https://github.com/NixOS/nixpkgs/pull/100462
+We can interpret this ratio of only 20% as a stalebot's failure to 
+effectively prompt action: The stalebot itself is stale, that is
+**impaired in vigor or effectiveness**. (your threshold of judgemnt may differ).
+
+To the author of this RFC, the most plausible reason is that by the time
+the stalbot interacts, levels of attentions and interest has vanished so
+might have memories or simpli life got into the way.
+
+At any rate, it is reasonable to assume, that this declining levels of attention
+iterest and memories put the very author into a position of beeing in a state
+that is **imparied in vigor and effectiveness**. So, you might have guessed it:
+the auther went stale. Dooms day! :wink:
+
+A reduction in the time to first interaction is likely a probate mean to prevent
+authors from going stale.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -75,6 +75,12 @@ should be provided with an escape hatch that maintainers can activate.
 _Note: non-maintainers are sufficiently unlikely to open truely long-runnig or umbrella 
 issues without a maintainer stepping up to prevent them from getting marked as stale._
 
+Since reconfiguring would trigger an immediate burst in notifications, the shift
+needs to be done gradually over a period of time, for example reduce by 5 days every
+two weeks.
+
+This graduation period also allows us to collect data on any manifest adverse effects.
+
 # Examples and Interactions
 [examples-and-interactions]: #examples-and-interactions
 

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -33,7 +33,7 @@ and an issue goes stale after a 60 days period (vs previously 180 days)._
 [motivation]: #motivation
 
 Under the renewed definition of _stale_ under this PR but the currently
-applied time preiods, spectators based on their common understanding 
+applied time periods, spectators based on their common understanding 
 are not told about  aggregate choices as a fair proxy of chances of 
 success by means of the stale label.
 
@@ -42,7 +42,7 @@ that are visibly exhibiting lack of interaction, and there by reduced
 chances of (prompt) "success".
 
 An issue that hasn't been interacted with for 60 days or a PR for 90 days
-and in the vas majority of cases deserve an aggregate indication of
+and in the vast majority of cases deserve an aggregate indication of
 those individual preferences for the above reason.
 
 Honesty and transparency are better in informing an individual's action

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -114,26 +114,64 @@ valuable information that is beeing broadcasted by the notification.
 # Supporting Data
 [data]: #supporting-data
 
-As of now, there are roughly 1750 open issues marked as stale, and
-roughly 450 stale issues were marked as closeed.
+As of now, the stale-bot has commented on roughly 2.2k open issues and
+roughly 500 closed issues (`is:issue commenter:app/stale`).
+
+Thereof, 1.7k are still `2.status: stale` and 400 are `2.status: stale`
+and closed.
+
+This gives us the following data:
+- 1.7k interactions did not trigger any action (effectively stale)
+- 400 interactions triggered an immediate close (stale label not removed)
+- 100 interactions are unkown, but the issue is closed now
+- 500 interactions did trigger any action so that the issue is not
+  `2. status: stale` ay more
+
+Since very old issues are likely to skew the data and the analysis,
+we limit the picture to issues created after 01.01.2019. Then, we get:
+
+The stalebot has commented on 1.1k open and 200 closed issues
+(`is:issue commenter:app/stale created:>2019-01-01`).
+
+Thereof 750 are open and labelled stale and 150 are closed and labelled stale.
+(`is:issue commenter:app/stale created:>2019-01-01 label:"2.status: stale"`)
+
+That means out of 1.3k interactions on relatively recent issues, 750 did 
+not trigger _any_ reaction. The sucess rate of stale-bot triggering action
+is thereby at 42% (37% all times).
+
+There is a portion of the 750 (1.7k) futile interactions, where spectators
+might have silently agreed the stale-bots assessment. So the following
+interpretation is not 100% accurate.
 
 ## Interpretation
 
-We can interpret this ratio of only 20% as a stalebot's failure to 
-effectively prompt action: The stalebot itself is stale, that is
-**impaired in vigor or effectiveness**. (your threshold of judgemnt may differ).
+We can interpret this ratio of 42% (37%) as a stalebot's moderate success.
+But it also can be interpreted as a relative failure, especially given
+the many instructions and tips the stale-bot puts at the hands
+of participants in its comments. In 58% (63%) of cases, the stalebot itself 
+is stale, that is **impaired in vigor or effectiveness**.
 
-To the author of this RFC, the most plausible reason is that by the time
-the stalebot interacts, levels of attention and interest have vanished. So
-might have memories or simply the life got in the way.
+To the author of this RFC, one aspect crutial aspect in open source low
+commitment environments is that by the time the stalebot interacts, levels
+of attention and interest have vanished. So might have memories or simply
+the life got in the way.
 
 At any rate, it is reasonable to assume, that this declining levels of attention,
 iterest and memories put the very author into a position of beeing 
 **imparied in vigor and effectiveness**. So, you might have guessed it:
 _the author went stale. Damn it!_ :wink:
 
+Author being stale, can be assumed for around 58% (63%) of total stalebot
+interactions or roughly 38% of total issues (1.7k out of 4.4k).
+
 A reduction in the time to first interaction is likely a probate mean to
 prevent authors from going stale.
+
+If we consider for a moment that 38% percent of issues have no care-taker
+and no real chance of getting promotion, this suggests, we need to increase
+our efforts to make our database more actionable and accurate. (closed does
+not mean deleted! _stale_ does not mean invalid!).
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -118,16 +118,16 @@ effectively prompt action: The stalebot itself is stale, that is
 **impaired in vigor or effectiveness**. (your threshold of judgemnt may differ).
 
 To the author of this RFC, the most plausible reason is that by the time
-the stalbot interacts, levels of attentions and interest has vanished so
-might have memories or simpli life got into the way.
+the stalebot interacts, levels of attention and interest have vanished. So
+might have memories or simply the life got in the way.
 
-At any rate, it is reasonable to assume, that this declining levels of attention
-iterest and memories put the very author into a position of beeing in a state
-that is **imparied in vigor and effectiveness**. So, you might have guessed it:
-the auther went stale. Dooms day! :wink:
+At any rate, it is reasonable to assume, that this declining levels of attention,
+iterest and memories put the very author into a position of beeing 
+**imparied in vigor and effectiveness**. So, you might have guessed it:
+_the author went stale. Damn it!_ :wink:
 
-A reduction in the time to first interaction is likely a probate mean to prevent
-authors from going stale.
+A reduction in the time to first interaction is likely a probate mean to
+prevent authors from going stale.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -88,28 +88,36 @@ With a renewed definition of the word _stale_ and removing an overly emotional
 meaning by virtue of this very PR, there is no reason to adversely interpret
 a bot spelling out the facts.
 
-One might think, that this increases the load of "spam" notifications on
-subscribers. However, the bot ifirst and foremost prompts and helps the author.
-Subscribers, most of the time, do not have the highest stakes in this interaction.
+Regular subscriber might get notiviations they do not find immediatly
+actionable for them personally. However, the bot is inteded to help authors,
+not (silent) subscribers. It is assumed that subscribers wisely choose
+and actively manage how they spread their limmited attention. At any rate,
+their interests should never outperform the interest of the auther (="owner").
 
 At a closer look, increased notification is also a valuable _gain_ in information
-for those subscribers. Imagine:
-
-A topic went stale, then there where people moving things forward. Then it went
-stale _again_. If I'm subscribed to a topic of _interest_, a second stale promts
-me to consider taking action.
-
+for those subscribers. Imagine: A topic went stale, then there where people moving
+things forward. Then it went stale _again_. If I'm subscribed to a topic of 
+_interest_, a second stale promts me to consider taking action.
 
 Some data: As of now, there are roughly 1750 open issues marked as stale, and
 roughly 450 stale issues were marked as closed. Even older ones. By definition
-of the stalbot, this means the stalebot has not prompted any action on the
-vast majority of interactions. That means, the stalebot is pretty inefective
-(since ignored). The most plausible root cause is that the stale bot promted
-after an inhumanely long period of time in which the interest of the proponent
-might have shifted to such extend that they completely ignore the stalebot.
-Maybe they don't remember, maybe life has come into the way. In any case
-a shorter period ensures that the memories (and by extension) interestes are
-still fresh.
+of how the stale bot operates, this means the stale bot has failed in adequately
+prompting action. The data suggests, it is _not_ actionable.
+
+There are a variety of possible reasons for this, but if we assume that the bot
+should have prompted the _author_ into "furthering the cause" (whatever that
+might be in a particular context), judging by the 1750 unattended interventions,
+it blatantly failed. Since any such furthering would have left traces the stalebot
+would have picked up in any way.
+
+One reason for this might be that by the time the stae bot intervenes, the
+interest and memory has vanished to a point where even the friendly suggestions
+of the stalebot are completely ignored. This strongly supports reducing the
+inactivity period to _humanly bearable levels_ of an avearge person with an
+average memory.
+
+Another reason might be that the stalebot is not actionable, since too convoluted
+and wordy. So nobody reads it. Hence: https://github.com/NixOS/nixpkgs/pull/100462
 
 # Alternatives
 [alternatives]: #alternatives

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -59,6 +59,7 @@ and 90 (3 months) for PRs is probably a good enough improvmeent over the current
 
 With shorter periods, people are also mor likely to still remember the relevant details, 
 so it gets easier for them to react in actionable ways to the bot's friendly reminder.
+Since PR are more involved, memories can be expected to be fresh a little longer. Hence: 90 days.
 
 Cases, where these dynamics, don't regularily aply (such as umbrell issues, etc.), 
 should be provided with an escape hatchi which maintainers can activate.

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -61,8 +61,8 @@ With shorter periods, people are also mor likely to still remember the relevant 
 so it gets easier for them to react in actionable ways to the bot's friendly reminder.
 Since PR are more involved, memories can be expected to be fresh a little longer. Hence: 90 days.
 
-Cases, where these dynamics, don't regularily aply (such as umbrell issues, etc.), 
-should be provided with an escape hatchi which maintainers can activate.
+Cases, where these dynamics don't regularily aply (such as umbrell issues, etc.) 
+should be provided with an escape hatch that maintainers can activate.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -148,6 +148,35 @@ If we can &mdash; at the seame time &mdash; increase the share of useful
 output en reasonable terms, we probably should bias our workflows towards
 actionability, even if this is not 100% pareto-efficient.
 
+---
+
+This RFC proposes to adopt a common definition of the word stale and thereby
+forgoes a hard earned consensus about an alternative definition of RFC 51.
+
+This RFC's stance is that consenus was reached based on teleological
+reasoning rather than experiment (or even data). This RFC promotes experiment
+through the graduation period and would explicitly leave open the possibilty
+to wind back upon significant and otherwise non-remediable data of adverse
+efects. It also takes a stance to represent the (admittedly construed) needs
+and preference of a significant portion of casual contributors, that I
+assume to not have had their voice in RFC 51's discussion.
+
+The assumption is that casual (inexperienced) contributors would benefit
+even from the interaction with a bot. I can tell myself, that I have had
+positive experiences which made my own contributinos more apt for reviewi,
+inclusion and promotion in general.
+
+Unfortunately, those casual contributors are consistently under-represented
+across the current workflows of the Nix* community. But signs can be
+percieved throughout the ecosystem, that some actors would wish to make
+Nix* more atractive to new contributors and man power (see also this year's 
+nixCon talks). This RFC is just a tiny screw in the gears.
+
+Consensus about the _significance_ of this single screw is expected not o be
+reached. Therefore this RFC will fail. But I hope it leaves a thought legacy
+of furthering the intricacies of the mentioned umbrella topic of promoting
+Nix* adoption.
+
 # Alternatives
 [alternatives]: #alternatives
 

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -129,6 +129,19 @@ _the author went stale. Damn it!_ :wink:
 A reduction in the time to first interaction is likely a probate mean to
 prevent authors from going stale.
 
+# Drawbacks
+[drawbacks]: #drawbacks
+
+A non-trivial share of issues get stale-bot request «what's the status», 
+then update from someone «checked, still happens».
+
+If the issue goes stale again after another 60 / 90 days, then the amount
+of unuseful traffic increases.
+
+If we can &mdash; at the seame time &mdash; increase the share of useful
+output en reasonable terms, we probably should bias our workflows towards
+actionability, even if this is not 100% pareto-efficient.
+
 # Alternatives
 [alternatives]: #alternatives
 
@@ -142,4 +155,5 @@ At the time of writing, no unresolved questions apear of relevance.
 # Future work
 [future]: #future-work
 
-No future work is required.
+Neutrally estimate the current share of instances where the drawback
+manifests based on observable data.

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -84,6 +84,29 @@ With a renewed definition of the word _stale_ and removing an overly emotional
 meaning by virtue of this very PR, there is no reason to adversely interpret
 a bot spelling out the facts.
 
+One might think, that this increases the load of "spam" notifications on
+subscribers. However, the bot ifirst and foremost prompts and helps the author.
+Subscribers, most of the time, do not have the highest stakes in this interaction.
+
+At a closer look, increased notification is also a valuable _gain_ in information
+for those subscribers. Imagine:
+
+A topic went stale, then there where people moving things forward. Then it went
+stale _again_. If I'm subscribed to a topic of _interest_, a second stale promts
+me to consider taking action.
+
+
+Some data: As of now, there are roughly 1750 open issues marked as stale, and
+roughly 450 stale issues were marked as closed. Even older ones. By definition
+of the stalbot, this means the stalebot has not prompted any action on the
+vast majority of interactions. That means, the stalebot is pretty inefective
+(since ignored). The most plausible root cause is that the stale bot promted
+after an inhumanely long period of time in which the interest of the proponent
+might have shifted to such extend that they completely ignore the stalebot.
+Maybe they don't remember, maybe life has come into the way. In any case
+a shorter period ensures that the memories (and by extension) interestes are
+still fresh.
+
 # Alternatives
 [alternatives]: #alternatives
 

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -32,10 +32,14 @@ aggregated indicator of facts. It reflects the fact that
 individuals did choose not to interact on a particular issue or PR
 for an extended period of time._
 
-_180 days is too long of such extended period of time. People do relate
-"stale" with some shorter time frame. Therefore, a PR goes stale after
-a 90 days period (vs previously 180 days) and an issue goes stale after
-a 60 days period (vs previously 180 days)._
+_180 days is too long of such extended period of time. In a majority
+of cases, an issue or PR enter into a state where they are
+**impaired in vigor or effectiveness** far earlier._
+
+_While it is difficult to judge on the exact date when they enter this
+state seems safe to assume that for PR 90 days and issues 60 days does
+assess the majority of cases correctly while keeping false positives 
+at bearably low levels, which everyone can live with._
 
 # Motivation
 [motivation]: #motivation

--- a/rfcs/0077-stale-issues-amendment.md
+++ b/rfcs/0077-stale-issues-amendment.md
@@ -25,7 +25,7 @@ _A stale issue (or PR) is an issue on which the discussion has went stale._
 
 _Explicitly, it has no other semantic than this. It is a neutral 
 aggregated indicator of facts. It reflects the fact that 
-individuals did choose not to not interact on a particular issue or PR
+individuals did choose not to interact on a particular issue or PR
 for an extended period of time._
 
 _180 days is too long of such extended period of time. People do relate
@@ -64,7 +64,7 @@ political correctness (judging by the discussions on RFC 51).
 [examples-and-interactions]: #examples-and-interactions
 
 It should be noted under this section, that it only takes a comment
-to un-satale an issue or PR.
+to un-stale an issue or PR.
 
 It should be made clear, that stale does **not** mean either of
 the following:


### PR DESCRIPTION
Based on: https://github.com/NixOS/nixpkgs/pull/100460#issuecomment-708093967

[Rendered](https://github.com/blaggacao/rfcs/blob/da-stale-period-amendemend/rfcs/0077-stale-issues-amendment.md)

---

Based on the first reactions and feedback, unfortunately, I have to clarify this:

- Please read carefully, this RFC does **not** [significantly increase the rate of notifications](https://github.com/NixOS/rfcs/pull/77#issuecomment-708528137).
- This RFC does **not** seek to impose anything on anyone (quite a few comments seem to interpret this RFC as an imposition to their customs or freedoms) &mdash; this is over-interpretation and is **not** the case. It seeks [transparency about the facts](https://github.com/NixOS/rfcs/pull/77/files#diff-fbe3cd7737f03e77c4358e752f5104c766f986bdf639a7cd6bb563bfac6b0a8fR26-R28). If an increase in transparency does prompt (some) people to actions, then this is a positive spill-over effect.
- There seems to be an implicit proxy discussion about different labels going on here (notably the `2.status: *` category). This RFC does not address the expressiveness of the current label structure. It assume it needs improvement, but a general overhaul might be something for a different RFC.
- Unfortunately, _authors_ &mdash; the primary target of the stale-bot's reminder &mdash; are likely to be systemically underrepresented in this RFC's discussion. So please read it with their eyes and needs, too. They are a diverse group &mdash; not only core or regular contributors.