### PR TITLE
[RFC 0102] Moderation Team

### DIFF
--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -75,6 +75,7 @@ ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
 
 # Alternatives
 [alternatives]: #alternatives
+* Define a consistuency of project participants and some (more bottom-up/grassroots) procedure with a foundation in popular support for specific moderators.
 
 * An existing [RFC 98][].
 * Do nothing.

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -3,8 +3,8 @@ feature: moderation team
 start-date: 2021-08-18
 author: tomberek
 co-authors: blaggacao
-shepherd-team: (names, to be nominated and accepted by RFC steering committee)
-shepherd-leader: (name to be appointed by RFC steering committee)
+shepherd-team: @ryantm, @7c6f434c, @IreneKnapp
+shepherd-leader: @zimbatm
 related-issues: https://github.com/NixOS/rfcs/pull/98
 ---
 
@@ -31,6 +31,7 @@ applications to the team or alter the composition at any time. The team's
 composition, contact information, procedures, moderation log, and announcements
 should be available via
 [https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
+The distribution of work within the team may be treated as an internal matter.
 The team shall perform moderation activities on behalf of the community - with
 oversight via the RFC process and input from the NixOS Foundation - for
 discussions in [official project

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -1,0 +1,92 @@
+---
+feature: moderation team
+start-date: 2021-08-18
+author: tomberek
+co-authors: blaggacao
+shepherd-team: (names, to be nominated and accepted by RFC steering committee)
+shepherd-leader: (name to be appointed by RFC steering committee)
+related-issues: https://github.com/NixOS/rfcs/pull/98
+---
+
+# Summary
+[summary]: #summary
+
+Establish a team to perform moderation.
+
+# Motivation
+[motivation]: #motivation
+
+There is not currently any official mechanism for moderation action. It's not
+sustainable to have to call on Graham any time there's a spammer or conflict
+that requires moderation, and we'd like to help the community become more
+self-regulating.
+
+(adopted from #98)
+
+# Detailed design
+[design]: #detailed-design
+
+The Moderation Team is a volunteer group that may receive and evaluate
+applications to the team or alter the composition at any time with approval
+from the NixOS Foundation board. The team's composition and announcements
+should be maintained at
+[https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
+The team shall perform moderation activities for the [community
+discussions](https://nixos.org/community/index.html) on behalf of the NixOS
+Foundation. The team should utilize the [NixOS Foundation
+mission](https://nixos.org/community/index.html) and the following statement
+during their duties:
+
+```
+The NixOS Foundation aims to promote participation without regard to gender,
+sexual orientation, disability, ethnicity, age, or similar personal
+characteristics. We want to strive to create and foster community by providing
+an intentionally welcoming and safe environment where all feel valued and cared
+for, and where all are given opportunity to participate meaningfully. The
+Foundation will work with the community in service of this goal.
+```
+
+ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
+
+# Examples and Interactions
+[examples-and-interactions]: #examples-and-interactions
+
+The initial Moderation Team is defined to be @grahamc, @zimbatm, @domenkozar,
+and @ryantm.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+* The moderation team has limited guidance from this RFC on the processes and
+  procedures of the team.
+* This RFC is designed to address a narrow part of a current issue facing the
+  community. Additional RFCs may be needed to address additional concerns.
+* As this is a controversial topic there is a potential this RFC does not have
+  enough detail to be acceptable by the overall community.
+
+# Alternatives
+[alternatives]: #alternatives
+
+* An existing [RFC 98][].
+* Do nothing.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+* Does the team require additional guidance?
+* Does the NixOS Foundation board want to be involved in this manner?
+
+# Future work
+[future]: #future-work
+
+* A potential RFC providing additional guidance and detail for the moderation
+  team's activities and functions.
+* The role of the moderation team could evolve through an effort similar to
+  [RFC 98][] into taking a broader community leadership responsibility as a
+  'Leadership Team' or 'Community Team'.
+* Further evolve our Community Governance by adopting typical governance tools,
+  such as [Contributor Covenant](https://www.contributor-covenant.org/),
+  Statements of Values, and others in order to provide better guiding
+  principles to our community.
+ 
+[RFC 98]: https://github.com/NixOS/rfcs/pull/98

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -87,8 +87,8 @@ and @ryantm.
   [RFC 98][] into taking a broader community leadership responsibility as a
   'Leadership Team' or 'Community Team'.
 * Work on clarifying community norm guidelines. This can include adopting
-  typical governance tools, such as [Contributor
-  Covenant](https://www.contributor-covenant.org/), Statements of Values, and
+  typical governance tools, such as Contributor
+  Covenant, Statements of Values, and
   others in order to provide better guiding principles to our community.
  
 [RFC 98]: https://github.com/NixOS/rfcs/pull/98

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -21,18 +21,19 @@ sustainable to have to call on Graham any time there's a spammer or conflict
 that requires moderation, and we'd like to help the community become more
 self-regulating.
 
-(adopted from #98)
+The intention behind this RFC is to codify the current moderation practices.
 
 # Detailed design
 [design]: #detailed-design
 
 The Moderation Team is a volunteer group that may receive, invite, and evaluate
 applications to the team or alter the composition at any time. The team's
-composition, contact information, procedures, and announcements should be
-maintained at
+composition, contact information, procedures, moderation log, and announcements
+should be available via
 [https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
 The team shall perform moderation activities on behalf of the community - with
-oversight via the RFC process - for discussions in [official project
+oversight via the RFC process and input from the NixOS Foundation - for
+discussions in [official project
 spaces](https://nixos.org/community/index.html) as well as unofficial spaces
 that seek and reach such an agreement with the team. The team should utilize
 the [NixOS Foundation mission](https://nixos.org/community/index.html) and the
@@ -52,8 +53,9 @@ ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
 # Examples and Interactions
 [examples-and-interactions]: #examples-and-interactions
 
-- The initial Moderation Team is defined to be @grahamc, @zimbatm, @domenkozar,
-  @Mic92, @garbas, and @ryantm.
+- The initial Moderation Team - drawn from the existing Discourse and GitHub
+  teams - is defined to be @grahamc, @zimbatm, @domenkozar, @Mic92, @garbas,
+  and @ryantm.
 - Rename the Discourse Team to Moderation Team on
   https://nixos.org/community/teams/discourse.html and utilize
   https://nixos.org/community/teams/moderation.html.

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -75,7 +75,7 @@ ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
 
 # Alternatives
 [alternatives]: #alternatives
-* Define a consistuency of project participants and some (more bottom-up/grassroots) procedure with a foundation in popular support for specific moderators.
+* Define a constituency of project participants and some (more bottom-up/grassroots) procedure with a foundation in popular support for specific moderators.
 
 * An existing [RFC 98][].
 * Do nothing.

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -26,16 +26,18 @@ self-regulating.
 # Detailed design
 [design]: #detailed-design
 
-The Moderation Team is a volunteer group that may receive and evaluate
+The Moderation Team is a volunteer group that may receive, invite, and evaluate
 applications to the team or alter the composition at any time with approval
-from the NixOS Foundation board. The team's composition and announcements
-should be maintained at
+from the NixOS Foundation board or by any individual choosing to resign. The
+team's composition, contact information, and announcements should be maintained
+at
 [https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
-The team shall perform moderation activities for the [community
-discussions](https://nixos.org/community/index.html) on behalf of the NixOS
-Foundation. The team should utilize the [NixOS Foundation
-mission](https://nixos.org/community/index.html) and the following statement
-during their duties:
+The team shall perform moderation activities on behalf of the NixOS Foundation
+for the discussions in the [official project
+spaces](https://nixos.org/community/index.html) as well as unofficial spaces
+that seek and reach such an agreement with the team. The team should utilize
+the [NixOS Foundation mission](https://nixos.org/community/index.html) and the
+following statement during their duties:
 
 ```
 The NixOS Foundation aims to promote participation without regard to gender,
@@ -84,9 +86,9 @@ and @ryantm.
 * The role of the moderation team could evolve through an effort similar to
   [RFC 98][] into taking a broader community leadership responsibility as a
   'Leadership Team' or 'Community Team'.
-* Further evolve our Community Governance by adopting typical governance tools,
-  such as [Contributor Covenant](https://www.contributor-covenant.org/),
-  Statements of Values, and others in order to provide better guiding
-  principles to our community.
+* Work on clarifying community norm guidelines. This can include adopting
+  typical governance tools, such as [Contributor
+  Covenant](https://www.contributor-covenant.org/), Statements of Values, and
+  others in order to provide better guiding principles to our community.
  
 [RFC 98]: https://github.com/NixOS/rfcs/pull/98

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -28,7 +28,8 @@ self-regulating.
 
 The Moderation Team is a volunteer group that may receive, invite, and evaluate
 applications to the team or alter the composition at any time. The team's
-composition, contact information, and announcements should be maintained at
+composition, contact information, procedures, and announcements should be
+maintained at
 [https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
 The team shall perform moderation activities on behalf of the community - with
 oversight via the RFC process - for discussions in [official project
@@ -51,8 +52,14 @@ ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
 # Examples and Interactions
 [examples-and-interactions]: #examples-and-interactions
 
-The initial Moderation Team is defined to be @grahamc, @zimbatm, @domenkozar,
-and @ryantm.
+- The initial Moderation Team is defined to be @grahamc, @zimbatm, @domenkozar,
+  @Mic92, @garbas, and @ryantm.
+- Rename the Discourse Team to Moderation Team on
+  https://nixos.org/community/teams/discourse.html and utilize
+  https://nixos.org/community/teams/moderation.html.
+- Establish and publish a clear point of contact for abuse reporting and a
+  venue for discussion about moderation specific topics such as a dedicated
+  Matrix channel or Discourse topic.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -27,13 +27,11 @@ self-regulating.
 [design]: #detailed-design
 
 The Moderation Team is a volunteer group that may receive, invite, and evaluate
-applications to the team or alter the composition at any time with approval
-from the NixOS Foundation board or by any individual choosing to resign. The
-team's composition, contact information, and announcements should be maintained
-at
+applications to the team or alter the composition at any time. The team's
+composition, contact information, and announcements should be maintained at
 [https://nixos.org/community/teams/moderation.html](https://nixos.org/community/teams/moderation.html).
-The team shall perform moderation activities on behalf of the NixOS Foundation
-for the discussions in the [official project
+The team shall perform moderation activities on behalf of the community - with
+oversight via the RFC process - for discussions in [official project
 spaces](https://nixos.org/community/index.html) as well as unofficial spaces
 that seek and reach such an agreement with the team. The team should utilize
 the [NixOS Foundation mission](https://nixos.org/community/index.html) and the


### PR DESCRIPTION
The intention behind this RFC is to directly address the motivating problem behind #98 in a minimal way, building upon what seem to be the general points of agreement:

1) There is a desire to improve our ability to perform community moderation
1) Trust in the existing moderators
1) Agreement with the mission and statements of the NixOS Foundation

This RFC presumes that the team will take a few steps to self-organize, determine effective procedures, and communicate with the community writ-large - but purposefully leaves the specific details for the team to decide.

[Rendered](https://github.com/tomberek/rfcs/blob/0102/rfcs/0102-moderation-team.md)

Edit: through discussion, the oversight role of the Foundation has been replaced by the RFC process.