### PR TITLE
[RFC 0114] Code of Conduct for NixOS Community

### DIFF
--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -19,8 +19,7 @@ inappropriate behavior when interacting with the community. This RFC aims
 to establish the shared values, so they can be used to identify behavior
 which is disruptive to the community.
 
-This RFC does not intend to define moderation practices. This is intended to only lay
-a framework of shared values for the community.
+This RFC does not intend to define moderation practices.
 
 # Motivation
 [motivation]: #motivation

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -102,7 +102,7 @@ existing [community ethos](https://nixos.org/community/index.html) as moderation
 # Future work
 [future]: #future-work
 
-- Ratification of a "NixOS moderation team" as described in the second to last bullet.
+- Ratification of a "NixOS moderation team" as described in the second to last bullet point.
 - Add Code of Conduct to nixos.org, and mention the Code of Conduct on all relevant
 repositories under the NixOS organization.
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -13,7 +13,7 @@ related-issues: #98 #102
 
 The Nix community needs some foundation of shared values which can be used
 to determine appropriate behavior when contributing and interacting with the community.
-We currently have a [community ethos](https://nixos.org/community/index.html), but
+We currently have a [community ethos](https://github.com/NixOS/nixos-homepage/blob/3f30d59a663c565dd3e43490898f5ab75d06e07f/community/index.tt#L11-L24), but
 this only states that we are an inclusive community, but doesn't define
 inappropriate behavior when interacting with the community. This RFC aims
 to establish the shared values, so they can be used to identify behavior

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -96,6 +96,9 @@ of unacceptable behavior.
 - #102 Codifies some of the existing moderation practices, and uses the
 existing [community ethos](https://nixos.org/community/index.html) as moderation criteria.
 
+- Use existing [community ethos](https://nixos.org/community/index.html) as moderation criteria.
+However, this only includes inclusive statements, and doesn't define unacceptable behavior.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -25,7 +25,7 @@ a framework of shared values for the community.
 # Motivation
 [motivation]: #motivation
 
-The NixOS community struggles with a clearly defined way in which someone's behavior may
+The NixOS community lacks a clearly defined way in which someone's behavior may
 be disruptive. A well-defined Code of Conduct gives an explicit
 set of expectations for all contributors, which will also make it easier to identify
 when behavior becomes disruptive.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -33,8 +33,9 @@ when behavior becomes disruptive.
 # Detailed design
 [design]: #detailed-design
 
-These statutes are largely taken from [rust-lang's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+These statutes are taken from [rust-lang's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
 which provides a great compromise between explicit behaviors and subjective goals.
+Only the moderation body name has been changed.
 
 - We are committed to providing a friendly, safe and welcoming environment for
 all, regardless of level of experience, gender identity and expression,

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -16,7 +16,7 @@ to determine appropriate when contributing and interacting with the community.
 We currently have a [community ethos](https://nixos.org/community/index.html), but
 this only states that we are an inclusive community, but doesn't define
 inappropriate behavior when interacting with the community. This RFC aims
-to established the shared values, so they can be used to identify behavior
+to establish the shared values, so they can be used to identify behavior
 which is disruptive to the community.
 
 This RFC does not intend to define moderation practices. This is intended to only lay

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -11,7 +11,7 @@ related-issues: #98 #102
 # Summary
 [summary]: #summary
 
-The NixOS Community needs some foundation of shared values which can be used
+The Nix community needs some foundation of shared values which can be used
 to determine appropriate behavior when contributing and interacting with the community.
 We currently have a [community ethos](https://nixos.org/community/index.html), but
 this only states that we are an inclusive community, but doesn't define

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -1,0 +1,107 @@
+---
+feature: NixOS Code of Conduct
+start-date: 2021-11-03
+author: @jonringer
+co-authors:
+shepherd-team:
+shepherd-leader:
+related-issues: #98 #102
+---
+
+# Summary
+[summary]: #summary
+
+The NixOS Community needs some foundation of shared values which can be used
+to determine appropriate when contributing and interacting with the community.
+We currently have a [community ethos](https://nixos.org/community/index.html), but
+this only states that we are an inclusive community, but doesn't define
+inappropriate behavior when interacting with the community. This RFC aims
+to established they shared values, so they can be used to identify behavior
+which is disruptive to the community.
+
+This RFC does not intend to define moderation practices. This is intended to only lay
+a framework of shared values for the community.
+
+# Motivation
+[motivation]: #motivation
+
+The NixOS community struggles with a clearly defined way in which someone's behavior may
+be disruptive. A well-defined Code of Conduct gives an explicit
+set of expectations for all contributors, which will also make it easier to identify
+when behavior becomes disruptive.
+
+# Detailed design
+[design]: #detailed-design
+
+These statutes are largely taken from [rust-lang's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+which provides a great compromise between explicit behaviors and subjective goals.
+
+- We are committed to providing a friendly, safe and welcoming environment for
+all, regardless of level of experience, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, nationality, or other similar characteristics.
+- Please avoid using overtly sexual aliases or other nicknames that might
+detract from a friendly, safe and welcoming environment for all.
+- Please be kind and courteous. There’s no need to be mean or rude.
+- Respect that people have differences of opinion and that every design or
+implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+- Please keep unstructured critique to a minimum. If you have solid ideas
+you want to experiment with, make a fork and see how it works.
+- We will exclude you from interaction if you insult, demean or harass anyone.
+That is not welcome behavior. We interpret the term “harassment” as including the definition in the
+[Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md);
+if you have any lack of clarity about what might be included in that concept,
+please read their definition. In particular, we don’t tolerate behavior that excludes
+people in socially marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel
+you have been or are being harassed or made uncomfortable by a community member,
+please contact one of the channel ops or any of the NixOS moderation team immediately.
+Whether you’re a regular contributor or a newcomer, we care about making this community
+a safe place for you and we’ve got your back.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+# Examples and Interactions
+[examples-and-interactions]: #examples-and-interactions
+
+There have been a few spectacular failures of communication and good faith within the community.
+Most notable recent examples include the [block evasion thread](https://discourse.nixos.org/t/github-block-evasion-is-not-acceptable/12763),
+heated discussions in [RFC #98](https://github.com/NixOS/rfcs/pull/98) and [RFC #111](https://github.com/NixOS/rfcs/pull/111).
+Each of these incidents have caused significant discussion on IRC (when it was still official),
+matrix, discourse, and would bleed over into github and even non-official platforms.
+These discussions are generally very polarizing, and causes an enormous amount
+of emotional and mental stress to those involved.
+These incidents are also very embarressing for the greater nix community,
+and not having a way to identify disruptive before it becomes a heated
+issue is detrimental to the health of the community.
+
+In conjunction with a moderation team (out-of-scope for this RFC), these incidents could have been
+better arbitrated as to have a more satisfactory resolution before escalation. This
+Code of Conduct will better equip the moderation process by providing clear expectations
+for behavior within the community.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- There are more "rules" for the community to follow. However, these statutes are intended to
+still allow individuals to participate within the community in a healthy way for all.
+
+# Alternatives
+[alternatives]: #alternatives
+
+- #98 Also provides an opinionated values and goals for the moderation team. However,
+these rules are less well-defined, and allow for broader interpretations
+of unacceptable behavior.
+
+- #102 Codifies some of the existing moderation practices, and uses the
+existing [community ethos](https://nixos.org/community/index.html) as moderation criteria.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+# Future work
+[future]: #future-work
+
+- Ratification of a "NixOS moderation team" as described in the second to last bullet.
+- Add Code of Conduct to nixos.org, and mention the Code of Conduct on all relevant
+repositories under the NixOS organization.
+

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -83,8 +83,8 @@ for behavior within the community.
 # Drawbacks
 [drawbacks]: #drawbacks
 
-- There are more "rules" for the community to follow. However, these statutes are intended to
-still allow individuals to participate within the community in a healthy way for all.
+- There are potentially more "rules" for the community to follow. However, many of these rules
+are enforced already under the current moderation team, but without an explicit definition.
 
 # Alternatives
 [alternatives]: #alternatives

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -50,7 +50,7 @@ implementation choice carries a trade-off and numerous costs. There is seldom a 
 you want to experiment with, make a fork and see how it works.
 - We will exclude you from interaction if you insult, demean or harass anyone.
 That is not welcome behavior. We interpret the term “harassment” as including the definition in the
-[Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md);
+[Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/b8ee50e7a9fc79c39c936830901f8863d493b7cd/citizen_code_of_conduct.md);
 if you have any lack of clarity about what might be included in that concept,
 please read their definition. In particular, we don’t tolerate behavior that excludes
 people in socially marginalized groups.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -70,7 +70,7 @@ and associated [block evasion discourse thread](https://discourse.nixos.org/t/gi
 heated discussions in [RFC #98](https://github.com/NixOS/rfcs/pull/98) and [RFC #111](https://github.com/NixOS/rfcs/pull/111).
 Each of these incidents have caused significant discussion on IRC (when it was still official),
 matrix, discourse, and would bleed over into github and even non-official platforms.
-These discussions are generally very polarizing, and causes an enormous amount
+These discussions are generally very polarizing, and cause an enormous amount
 of emotional and mental stress to those involved.
 These incidents are also very embarrassing for the greater nix community,
 and not having a way to identify disruptive before it becomes a heated

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -16,7 +16,7 @@ to determine appropriate when contributing and interacting with the community.
 We currently have a [community ethos](https://nixos.org/community/index.html), but
 this only states that we are an inclusive community, but doesn't define
 inappropriate behavior when interacting with the community. This RFC aims
-to established they shared values, so they can be used to identify behavior
+to established the shared values, so they can be used to identify behavior
 which is disruptive to the community.
 
 This RFC does not intend to define moderation practices. This is intended to only lay

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -24,7 +24,7 @@ This RFC does not intend to define moderation practices.
 # Motivation
 [motivation]: #motivation
 
-The NixOS community lacks a clearly defined way in which someone's behavior may
+The Nix community lacks a clearly defined way to determine if someone's behavior may
 be disruptive. A well-defined Code of Conduct gives an explicit
 set of expectations for all contributors, which will also make it easier to identify
 when behavior becomes disruptive.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -65,7 +65,8 @@ a safe place for you and we’ve got your back.
 [examples-and-interactions]: #examples-and-interactions
 
 There have been a few spectacular failures of communication and good faith within the community.
-Most notable recent examples include the [block evasion thread](https://discourse.nixos.org/t/github-block-evasion-is-not-acceptable/12763),
+Most notable recent examples include [ad-hominem attacks in a PR review](https://github.com/NixOS/nixpkgs/pull/120729#discussion_r621885348)
+and associated [block evasion discourse thread](https://discourse.nixos.org/t/github-block-evasion-is-not-acceptable/12763),
 heated discussions in [RFC #98](https://github.com/NixOS/rfcs/pull/98) and [RFC #111](https://github.com/NixOS/rfcs/pull/111).
 Each of these incidents have caused significant discussion on IRC (when it was still official),
 matrix, discourse, and would bleed over into github and even non-official platforms.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -40,7 +40,7 @@ Only the moderation body name has been changed.
 - We are committed to providing a friendly, safe and welcoming environment for
 all, regardless of level of experience, gender identity and expression,
 sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
-religion, nationality, or other similar characteristics.
+religion (or lack thereof), socioeconomic status, nationality, or other similar characteristics.
 - Please avoid using overtly sexual aliases or other nicknames that might
 detract from a friendly, safe and welcoming environment for all.
 - Please be kind and courteous. There’s no need to be mean or rude.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -72,7 +72,7 @@ Each of these incidents have caused significant discussion on IRC (when it was s
 Matrix, Discourse, and would bleed over into GitHub and even non-official platforms.
 These discussions are generally very polarizing, and cause an enormous amount
 of emotional and mental stress to those involved.
-These incidents are also very embarrassing for the greater nix community,
+These incidents are also very embarrassing for the entire Nix community,
 and not having a way to identify disruptive before it becomes a heated
 issue is detrimental to the health of the community.
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-feature: NixOS Code of Conduct
+feature: Nix Community Code of Conduct
 start-date: 2021-11-03
 author: @jonringer
 co-authors:

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -3,7 +3,7 @@ feature: NixOS Code of Conduct
 start-date: 2021-11-03
 author: @jonringer
 co-authors:
-shepherd-team:
+shepherd-team: @edolstra @zimbatm @winterqt
 shepherd-leader:
 related-issues: #98 #102
 ---

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -16,7 +16,7 @@ to determine appropriate behavior when contributing and interacting with the com
 We currently have a [community ethos](https://github.com/NixOS/nixos-homepage/blob/3f30d59a663c565dd3e43490898f5ab75d06e07f/community/index.tt#L11-L24), but
 this only states that we are an inclusive community, but doesn't define
 inappropriate behavior when interacting with the community. This RFC aims
-to establish the shared values, so they can be used to identify behavior
+to establish such shared values, so they can be used to identify behavior
 which is disruptive to the community.
 
 This RFC does not intend to define moderation practices.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -106,7 +106,6 @@ However, this only includes inclusive statements, and doesn't define unacceptabl
 # Future work
 [future]: #future-work
 
-- Ratification of a "NixOS moderation team" as described in the second to last bullet point.
 - Add Code of Conduct to nixos.org, and mention the Code of Conduct on all relevant
 repositories under the NixOS organization.
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -69,7 +69,7 @@ Most notable recent examples include [ad-hominem attacks in a PR review](https:/
 and associated [block evasion discourse thread](https://discourse.nixos.org/t/github-block-evasion-is-not-acceptable/12763),
 heated discussions in [RFC #98](https://github.com/NixOS/rfcs/pull/98) and [RFC #111](https://github.com/NixOS/rfcs/pull/111).
 Each of these incidents have caused significant discussion on IRC (when it was still official),
-matrix, discourse, and would bleed over into github and even non-official platforms.
+Matrix, Discourse, and would bleed over into GitHub and even non-official platforms.
 These discussions are generally very polarizing, and cause an enormous amount
 of emotional and mental stress to those involved.
 These incidents are also very embarrassing for the greater nix community,

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -35,7 +35,7 @@ when behavior becomes disruptive.
 
 These statutes are taken from [rust-lang's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
 which provides a great compromise between explicit behaviors and subjective goals.
-Only the moderation body name has been changed.
+Only minor changes have been made.
 
 - We are committed to providing a friendly, safe and welcoming environment for
 all, regardless of level of experience, gender identity and expression,

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -38,7 +38,7 @@ Only minor changes have been made.
 - We are committed to providing a friendly, safe and welcoming environment for
 all, regardless of level of experience, gender identity and expression,
 sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
-religion (or lack thereof), socioeconomic status, nationality, or other similar characteristics.
+religion (or absence thereof), socioeconomic status, nationality, or other similar characteristics.
 - Please avoid using overtly sexual aliases or other nicknames that might
 detract from a friendly, safe and welcoming environment for all.
 - Please be kind and courteous. There’s no need to be mean or rude.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -45,7 +45,7 @@ religion, nationality, or other similar characteristics.
 detract from a friendly, safe and welcoming environment for all.
 - Please be kind and courteous. There’s no need to be mean or rude.
 - Respect that people have differences of opinion and that every design or
-implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+implementation choice carries a trade-off and numerous costs. There is seldom a single right answer.
 - Please keep unstructured critique to a minimum. If you have solid ideas
 you want to experiment with, make a fork and see how it works.
 - We will exclude you from interaction if you insult, demean or harass anyone.

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -71,7 +71,7 @@ Each of these incidents have caused significant discussion on IRC (when it was s
 matrix, discourse, and would bleed over into github and even non-official platforms.
 These discussions are generally very polarizing, and causes an enormous amount
 of emotional and mental stress to those involved.
-These incidents are also very embarressing for the greater nix community,
+These incidents are also very embarrassing for the greater nix community,
 and not having a way to identify disruptive before it becomes a heated
 issue is detrimental to the health of the community.
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -31,7 +31,7 @@ set of expectations for all contributors, and makes it easier to identify disrup
 # Detailed design
 [design]: #detailed-design
 
-These statutes are taken from [rust-lang's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+These statutes are taken from [Rust's Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
 which provides a great compromise between explicit behaviors and subjective goals.
 Only minor changes have been made.
 

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -26,8 +26,7 @@ This RFC does not intend to define moderation practices.
 
 The Nix community lacks a clearly defined way to determine if someone's behavior may
 be disruptive. A well-defined Code of Conduct gives an explicit
-set of expectations for all contributors, which will also make it easier to identify
-when behavior becomes disruptive.
+set of expectations for all contributors, and makes it easier to identify disruptive behavior.
 
 # Detailed design
 [design]: #detailed-design

--- a/rfcs/0114-nixos-code-of-conduct.md
+++ b/rfcs/0114-nixos-code-of-conduct.md
@@ -12,7 +12,7 @@ related-issues: #98 #102
 [summary]: #summary
 
 The NixOS Community needs some foundation of shared values which can be used
-to determine appropriate when contributing and interacting with the community.
+to determine appropriate behavior when contributing and interacting with the community.
 We currently have a [community ethos](https://nixos.org/community/index.html), but
 this only states that we are an inclusive community, but doesn't define
 inappropriate behavior when interacting with the community. This RFC aims


### PR DESCRIPTION
A lot of the recent heated discussion around #98, #102, #111 highlights a lack of alignment in how the community should participate with others.

This also overlaps with the goals and value section of #98 

[Rendered](https://github.com/jonringer/rfcs/blob/code-of-conduct/rfcs/0114-nixos-code-of-conduct.md)