### PR TITLE
[RFC 0137] Nix language versioning

### DIFF
--- a/rfcs/0137-nix-language-version.md
+++ b/rfcs/0137-nix-language-version.md
@@ -3,8 +3,8 @@ feature: nix-language-version
 start-date: 2022-12-12
 author: @fricklerhandwerk @yorickvp
 co-authors: @thufschmitt @Ericson2314 @infinisil
-shepherd-team:
-shepherd-leader:
+shepherd-team: @piegamesde @sternenseemann @gabriel-doriath-dohler
+shepherd-leader: @sternenseemann
 related-issues: https://github.com/NixOS/nix/issues/7255
 ---
 


### PR DESCRIPTION
Introduce a convention to determine which version of the Nix language grammar to use for parsing and evaluating Nix expressions.
Add parameters to the Nix language evaluator, controlling the behavior of deprecation warnings and errors.

Design goals: avoid breaking existing code, prevent inadvertently breaking reproducibility, minimise maintenance burden for implementors and users.

Regardless, changes to the language, especially breaking changes, should remain a rare exception.

[Rendered](https://github.com/fricklerhandwerk/rfcs/blob/rfc-137/rfcs/0137-nix-language-version.md)

Reviewers: Please add inline comments adding your arguments as suggestions, ideally one per comment. Resolving these conversations will keep the amount of foreground information tightly limited to what's still relevant.

Readers: No need to inspect closed comments, the considerations and conclusions there can be assumed to be part of the RFC text.

Please, do not add regular comments concerning contents! Otherwise we will lose track quickly.
Reserve regular comments for procedural issues, such as determining shepherds.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨