### PR TITLE
[RFC 136] Fix typo

### DIFF
--- a/rfcs/0136-stabilize-incrementally.md
+++ b/rfcs/0136-stabilize-incrementally.md
@@ -379,7 +379,7 @@ None at this time.
 # Future work
 [future]: #future-work
 
-Generalizing features (live pure eval and search) to work without Flakes might be desired by the Flake-skeptic faction, but is purposely left as future work in order to not delay stabilization.
+Generalizing features (like pure eval and search) to work without Flakes might be desired by the Flake-skeptic faction, but is purposely left as future work in order to not delay stabilization.
 
 General feature stability lifecycle: https://discourse.nixos.org/t/potential-rfc-idea-stability/27055
 


### PR DESCRIPTION
This typo got added at the last minute while other mistakes were being corrected. See [1] and [2].

[1]: <https://github.com/NixOS/rfcs/pull/136#discussion_r1292537175>
[2]: <https://github.com/NixOS/rfcs/pull/136/commits/64fe8f30d9b75b78f6dd81359b14f5ac95abce93>