### PR TITLE
Don't moderate discussions about moderation

### DIFF
--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -49,7 +49,7 @@ for, and where all are given opportunity to participate meaningfully. The
 Foundation will work with the community in service of this goal.
 ```
 
-ref: [twitter](https://twitter.com/grhmc/status/1390775249424338944)
+Discussions about moderation must not be moderated.
 
 # Examples and Interactions
 [examples-and-interactions]: #examples-and-interactions


### PR DESCRIPTION
Implement "nemo iudex in sua causa" to ensure that moderation powers cannot be used to censor discussions about moderation.

I am also removing the twitter link, which is dead.