### PR TITLE
Make markdown detectable by linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
This makes the project show up as being written in Markdown, which is common for these kinds of repos:
- https://github.com/swiftlang/swift-evolution/blob/main/.gitattributes
- https://github.com/Kotlin/KEEP/pull/332
- https://github.com/lit/rfcs/pull/40