### PR TITLE
ci: update labels on merged PRs

### DIFF
--- a/.github/workflows/update-pr-labels.yml
+++ b/.github/workflows/update-pr-labels.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   after-merge:
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'status: FCP')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -15,11 +16,7 @@ jobs:
       - name: Update labels on accepted RFCs
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
-          # Only operate on PR if it has the `status: accepted` label
-          if gh pr view $PR_NUMBER --repo $REPO --json labels -q 'any(.[].name == "status: accepted")'; then
-            gh pr edit $PR_NUMBER --remove-label "status: accepted" --repo $REPO
-            gh pr edit $PR_NUMBER --add-label "status: merged" --repo $REPO
-          fi
+          gh pr edit $PR_NUMBER --remove-label "status: FCP" --add-label "status: accepted"

--- a/.github/workflows/update-pr-labels.yml
+++ b/.github/workflows/update-pr-labels.yml
@@ -12,10 +12,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: cachix/install-nix-action@v30
-
-      - run: nix-env -iA nixpkgs.github-cli
-
       - name: Update labels on accepted RFCs
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-pr-labels.yml
+++ b/.github/workflows/update-pr-labels.yml
@@ -16,14 +16,14 @@ jobs:
 
       - run: nix-env -iA nixpkgs.github-cli
 
-      - name: Update PR Labels
+      - name: Update labels on accepted RFCs
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Remove `status: accepted` label, if present
-          gh pr edit $PR_NUMBER --remove-label "status: accepted" --repo $REPO || true
-          
-          # Add `status: merged` label
-          gh pr edit $PR_NUMBER --add-label "status: merged" --repo $REPO
+          # Only operate on PR if it has the `status: accepted` label
+          if gh pr view $PR_NUMBER --repo $REPO --json labels -q 'any(.[].name == "status: accepted")'; then
+            gh pr edit $PR_NUMBER --remove-label "status: accepted" --repo $REPO
+            gh pr edit $PR_NUMBER --add-label "status: merged" --repo $REPO
+          fi

--- a/.github/workflows/update-pr-labels.yml
+++ b/.github/workflows/update-pr-labels.yml
@@ -1,0 +1,29 @@
+name: Update PR labels
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  after-merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: cachix/install-nix-action@v30
+
+      - run: nix-env -iA nixpkgs.github-cli
+
+      - name: Update PR Labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Remove `status: accepted` label, if present
+          gh pr edit $PR_NUMBER --remove-label "status: accepted" --repo $REPO || true
+          
+          # Add `status: merged` label
+          gh pr edit $PR_NUMBER --add-label "status: merged" --repo $REPO


### PR DESCRIPTION
Updates labels when an RFC gets merged:

`status: FCP` -> `status: accepted`

There might be more automation we want to do, this is just what seemed most obvious to me at the moment.