### PR TITLE
Fix invalid YAML formatting

### DIFF
--- a/rfcs/0032-run-phase-changes-for-better-nix-shell-use.md
+++ b/rfcs/0032-run-phase-changes-for-better-nix-shell-use.md
@@ -1,8 +1,8 @@
 ---
 feature: run-phase-changes-for-better-nix-shell-use
 start-date: 2018-08-26
-author: @globin
-co-authors: @dezgeg
+author: "@globin"
+co-authors: "@dezgeg"
 related-issues: https://github.com/dezgeg/nixpkgs/tree/better-run-phases
 shepherd-team: Samuel Dionne-Reil, John Ericson, Linus Heckemann
 shepherd-leader: Linus Heckemann

--- a/rfcs/0051-mark-stale-issues.md
+++ b/rfcs/0051-mark-stale-issues.md
@@ -3,8 +3,8 @@ feature: mark-stale-issues
 start-date: 2019-08-24
 author: Ryan Mulligan
 co-authors: (find a buddy later to help our with the RFC)
-shepherd-team: @globin, @grahamc, and @peti
-shepherd-leader: @peti
+shepherd-team: "@globin, @grahamc, and @peti"
+shepherd-leader: "@peti"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0071-retired-committers-amendment.md
+++ b/rfcs/0071-retired-committers-amendment.md
@@ -3,8 +3,8 @@ feature: retired-committers-amendment
 start-date: 2020-07-09
 author: worldofpeace
 co-authors: Graham Christensen (@grahamc), Jan Tojnar (@jtojnar)
-shepherd-team: @lheckemann, @tilpner, @alyssais
-shepherd-leader: @tilpner
+shepherd-team: "@lheckemann, @tilpner, @alyssais"
+shepherd-leader: "@tilpner"
 related-issues: 0055
 ---
 

--- a/rfcs/0080-nixos-release-schedule.md
+++ b/rfcs/0080-nixos-release-schedule.md
@@ -3,7 +3,7 @@ feature: nixos-release-schedule
 start-date: 2020-11-28
 author: Jonathan Ringer (@jonringer)
 co-authors: Frederik Rietdijk (@FRidh)
-shepherd-team: @ryantm, @domenkozar and @garbas
+shepherd-team: "@ryantm, @domenkozar and @garbas"
 related-issues:
 ---
 

--- a/rfcs/0085-nixos-release-stablization.md
+++ b/rfcs/0085-nixos-release-stablization.md
@@ -3,9 +3,9 @@ feature: nixos-release-stablization
 start-date: 2021-01-17
 author: Jonathan Ringer (@jonringer)
 co-authors:
-shepherd-team: @ryantm, @garbas, @Mic92
-shepherd-leader: @ryantm
-related-issues: [NixOS release schedule](https://github.com/NixOS/rfcs/pull/80)
+shepherd-team: "@ryantm, @garbas, @Mic92"
+shepherd-leader: "@ryantm"
+related-issues: "[NixOS release schedule](https://github.com/NixOS/rfcs/pull/80)"
 ---
 
 # Summary

--- a/rfcs/0088-nixpkgs-breaking-change-policy.md
+++ b/rfcs/0088-nixpkgs-breaking-change-policy.md
@@ -3,8 +3,8 @@ feature: nixpkgs-breaking-change-policy
 start-date: 2020-09-24
 author: Kevin Cox
 co-authors: (TBD)
-shepherd-team: @blaggacao, @jonringer, @nrdxp
-shepherd-leader: @blaggacao
+shepherd-team: "@blaggacao, @jonringer, @nrdxp"
+shepherd-leader: "@blaggacao"
 related-issues: (TBD)
 ---
 

--- a/rfcs/0089-collect-non-source-package-meta.md
+++ b/rfcs/0089-collect-non-source-package-meta.md
@@ -3,8 +3,8 @@ feature: collect-non-source-package-meta
 start-date: 2021-03-14
 author: Robert Scott
 co-authors: (find a buddy later to help out with the RFC)
-shepherd-team: @asymmetric, @aforemny, @alyssais
-shepherd-leader: @asymmetric
+shepherd-team: "@asymmetric, @aforemny, @alyssais"
+shepherd-leader: "@asymmetric"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0092-plan-dynamism.md
+++ b/rfcs/0092-plan-dynamism.md
@@ -3,8 +3,8 @@ feature: plan-dynamism-experiment
 start-date: 2019-02-01
 author: John Ericson (@Ericson2314)
 co-authors: Las Safin (@L-as)
-shepherd-team: @tomberek, @ldesgoui, @gytis-ivaskevicius, @edolstra 
-shepherd-leader: @tomberek
+shepherd-team: "@tomberek, @ldesgoui, @gytis-ivaskevicius, @edolstra" 
+shepherd-leader: "@tomberek"
 related-issues: https://github.com/NixOS/nix/pull/4628 https://github.com/NixOS/nix/pull/5364 https://github.com/NixOS/nix/pull/4543 https://github.com/NixOS/nix/pull/3959
 ---
 

--- a/rfcs/0094-use-matrix-for-official-chat.md
+++ b/rfcs/0094-use-matrix-for-official-chat.md
@@ -1,9 +1,9 @@
 ---
 feature: use-matrix-for-official-chat
 start-date: 2020-05-19
-author: @ryantm and others
-shepherd-team: @grahamc, @joepie91, @andir, @mweinelt
-shepherd-leader: @grahamc
+author: "@ryantm and others"
+shepherd-team: "@grahamc, @joepie91, @andir, @mweinelt"
+shepherd-leader: "@grahamc"
 ---
 
 # Summary

--- a/rfcs/0097-no-read-store-dir.md
+++ b/rfcs/0097-no-read-store-dir.md
@@ -3,8 +3,8 @@ feature: nix-store-perms
 start-date: 2021-07-04
 author: Las Safin
 co-authors:
-shepherd-team: @kevincox @7c6f434c @edolstra
-shepherd-leader: @edolstra
+shepherd-team: "@kevincox @7c6f434c @edolstra"
+shepherd-leader: "@edolstra"
 related-issues:
 ---
 

--- a/rfcs/0102-moderation-team.md
+++ b/rfcs/0102-moderation-team.md
@@ -3,8 +3,8 @@ feature: moderation team
 start-date: 2021-08-18
 author: tomberek
 co-authors: blaggacao
-shepherd-team: @ryantm, @7c6f434c, @IreneKnapp
-shepherd-leader: @zimbatm
+shepherd-team: "@ryantm, @7c6f434c, @IreneKnapp"
+shepherd-leader: "@zimbatm"
 related-issues: https://github.com/NixOS/rfcs/pull/98
 ---
 

--- a/rfcs/0106-nix-release-schedule.md
+++ b/rfcs/0106-nix-release-schedule.md
@@ -3,8 +3,8 @@ feature: Nix release schedule
 start-date: 2021-09-23
 author: Eelco Dolstra
 co-authors: (find a buddy later to help out with the RFC)
-shepherd-team: @Ericson2314, @regnat, @Ma27, @tomberek
-shepherd-leader: @tomberek
+shepherd-team: "@Ericson2314, @regnat, @Ma27, @tomberek"
+shepherd-leader: "@tomberek"
 related-issues: N/A
 ---
 

--- a/rfcs/0108-nixos-containers.md
+++ b/rfcs/0108-nixos-containers.md
@@ -3,8 +3,8 @@ feature: NixOS Container rewrite
 start-date: 2021-02-14
 author: Maximilian Bosch <maximilian@mbosch.me>
 co-authors: n/a
-shepherd-team: @Mic92, @lheckemann, @SuperSandro2000, @arianvp, @Lassulus 
-shepherd-leader: @Lassulus 
+shepherd-team: "@Mic92, @lheckemann, @SuperSandro2000, @arianvp, @Lassulus" 
+shepherd-leader: "@Lassulus" 
 related-issues:
   - https://github.com/NixOS/nixpkgs/issues/69414
   - https://github.com/NixOS/nixpkgs/issues/67265

--- a/rfcs/0119-testing-conventions.md
+++ b/rfcs/0119-testing-conventions.md
@@ -3,10 +3,10 @@ feature: Defined conventions around testing of official Nixpkgs packages.
 start-date: 2021-12-29
 author: Jonathan Ringer
 co-authors:
-shepherd-team: @Mic92 @Artturin @kevincox
-shepherd-leader: @Mic92
+shepherd-team: "@Mic92 @Artturin @kevincox"
+shepherd-leader: "@Mic92"
 related-issues:
-  - [RFC 0088 - Nixpkgs Breaking Change Policy](https://github.com/NixOS/rfcs/pull/88)
+  - "[RFC 0088 - Nixpkgs Breaking Change Policy](https://github.com/NixOS/rfcs/pull/88)"
 ---
 
 # Summary

--- a/rfcs/0124-nix-mark-stale-issues.md
+++ b/rfcs/0124-nix-mark-stale-issues.md
@@ -3,8 +3,8 @@ feature: nix-mark-stale-issues
 start-date: 2022-04-18
 author: John Ericson (@Ericson2314)
 co-authors: (find a buddy later to help out with the RFC)
-shepherd-team: @ryantm, @nh2, @infinisil
-shepherd-leader: @ryantm
+shepherd-team: "@ryantm, @nh2, @infinisil"
+shepherd-leader: "@ryantm"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0125-bootspec.md
+++ b/rfcs/0125-bootspec.md
@@ -3,8 +3,8 @@ feature: bootspec
 start-date: 2022-05-09
 author: Graham Christensen
 co-authors: Cole Helbling
-shepherd-team: @lheckemann, @06kellyjac, @GovanifY, @RaitoBezarius
-shepherd-leader: @lheckemann
+shepherd-team: "@lheckemann, @06kellyjac, @GovanifY, @RaitoBezarius"
+shepherd-leader: "@lheckemann"
 related-issues: https://github.com/NixOS/nixpkgs/pull/172237
 ---
 

--- a/rfcs/0127-issues-warnings.md
+++ b/rfcs/0127-issues-warnings.md
@@ -3,8 +3,8 @@ feature: issues-warnings
 start-date: 2022-06-11
 author: piegames
 co-authors: —
-shepherd-team: @RaitoBezarius, @mweinelt, @infinisil
-shepherd-leader: @mweinelt
+shepherd-team: "@RaitoBezarius, @mweinelt, @infinisil"
+shepherd-leader: "@mweinelt"
 related-issues: https://github.com/NixOS/nixpkgs/pull/177272
 ---
 

--- a/rfcs/0130-stalled-rfcs.md
+++ b/rfcs/0130-stalled-rfcs.md
@@ -3,8 +3,8 @@ feature: stalled-rfcs
 start-date: 2022-06-01
 author: kevincox
 co-authors: spacekookie
-shepherd-team: @ryantm, @tomberek, @7c6f434c 
-shepherd-leader: @ryantm
+shepherd-team: "@ryantm, @tomberek, @7c6f434c" 
+shepherd-leader: "@ryantm"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0132-meson-builds-nix.md
+++ b/rfcs/0132-meson-builds-nix.md
@@ -2,9 +2,9 @@
 feature: meson_builds_nix
 start-date: 2022-08-25
 author: Anderson Torres
-co-authors: @p01arst0rm
-shepherd-team: @Ericson2314 @edolstra @thufschmitt
-shepherd-leader: @Ericson2314
+co-authors: "@p01arst0rm"
+shepherd-team: "@Ericson2314 @edolstra @thufschmitt"
+shepherd-leader: "@Ericson2314"
 related-issues:
 ---
 

--- a/rfcs/0136-stabilize-incrementally.md
+++ b/rfcs/0136-stabilize-incrementally.md
@@ -3,8 +3,8 @@ feature: stabilize-incrementally
 start-date: 2022-09-15
 author: John Ericson
 co-authors: (find a buddy later to help out with the RFC)
-shepherd-team: @thufschmitt @tomberek @infinisil
-shepherd-leader: @tomberek
+shepherd-team: "@thufschmitt @tomberek @infinisil"
+shepherd-leader: "@tomberek"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0145-doc-strings.md
+++ b/rfcs/0145-doc-strings.md
@@ -3,8 +3,8 @@ feature: doc-comment-standard
 start-date: 2023-03-27
 author: hsjobeki
 co-authors: --
-shepherd-team: @DavHau; @sternenseemann; @asymmetric
-shepherd-leader: @lassulus
+shepherd-team: "@DavHau; @sternenseemann; @asymmetric"
+shepherd-leader: "@lassulus"
 related-issues: (will contain links to implementation PRs)
 ---
 

--- a/rfcs/0146-meta-categories.md
+++ b/rfcs/0146-meta-categories.md
@@ -3,8 +3,8 @@ feature: Decouple filesystem from categorization
 start-date: 2023-04-23
 author: Anderson Torres (@AndersonTorres)
 co-authors:
-shepherd-team: @7c6f434c @natsukium @fgaz
-shepherd-leader: @7c6f434c
+shepherd-team: "@7c6f434c @natsukium @fgaz"
+shepherd-leader: "@7c6f434c"
 related-issues: (will contain links to implementation PRs)
 ---
 


### PR DESCRIPTION
- YAML strings cannot start with `@` (affected 22 files)
- YAML strings cannot start with `[` (affected 2 files)

In both cases we can just double-quote the value to fix the problem.